### PR TITLE
support tenant config for ruler

### DIFF
--- a/cmd/controller-manager/app/controllers.go
+++ b/cmd/controller-manager/app/controllers.go
@@ -46,11 +46,12 @@ func addControllers(mgr manager.Manager, client k8s.Client, informerFactory info
 	}
 
 	if err := (&monitoring.ThanosRulerReconciler{
-		DefaulterValidator: monitoring.CreateThanosRulerDefaulterValidator(*cmOptions.MonitoringOptions),
-		ReloaderConfig:     cmOptions.MonitoringOptions.PrometheusConfigReloader,
-		Client:             mgr.GetClient(),
-		Scheme:             mgr.GetScheme(),
-		Context:            ctx,
+		DefaulterValidator:    monitoring.CreateThanosRulerDefaulterValidator(*cmOptions.MonitoringOptions),
+		ReloaderConfig:        cmOptions.MonitoringOptions.PrometheusConfigReloader,
+		RulerQueryProxyConfig: cmOptions.MonitoringOptions.RulerQueryProxy,
+		Client:                mgr.GetClient(),
+		Scheme:                mgr.GetScheme(),
+		Context:               ctx,
 	}).SetupWithManager(mgr); err != nil {
 		klog.Errorf("Unable to create ThanosRuler controller: %v", err)
 		return err

--- a/config/bundle.yaml
+++ b/config/bundle.yaml
@@ -5633,6 +5633,9 @@ spec:
                     description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
+              tenant:
+                description: Tenant if not empty indicates which tenant's data is evaluated for the selected rules; otherwise, it is for all tenants.
+                type: string
               tolerations:
                 description: If specified, the pod's tolerations.
                 items:

--- a/config/crd/bases/monitoring.paodin.io_thanosrulers.yaml
+++ b/config/crd/bases/monitoring.paodin.io_thanosrulers.yaml
@@ -1444,6 +1444,10 @@ spec:
                       are ANDed.
                     type: object
                 type: object
+              tenant:
+                description: Tenant if not empty indicates which tenant's data is
+                  evaluated for the selected rules; otherwise, it is for all tenants.
+                type: string
               tolerations:
                 description: If specified, the pod's tolerations.
                 items:

--- a/pkg/api/monitoring/v1alpha1/service_types.go
+++ b/pkg/api/monitoring/v1alpha1/service_types.go
@@ -461,6 +461,10 @@ type ThanosRulerSpec struct {
 	// the same namespace as the ThanosRuler object is in is used.
 	RuleNamespaceSelector *metav1.LabelSelector `json:"ruleNamespaceSelector,omitempty"`
 
+	// Tenant if not empty indicates which tenant's data is evaluated for the selected rules;
+	// otherwise, it is for all tenants.
+	Tenant string `json:"tenant,omitempty"`
+
 	// Labels configure the external label pairs to ThanosRuler. A default replica label
 	// `thanos_ruler_replica` will be always added  as a label with the value of the pod's name and it will be dropped in the alerts.
 	Labels map[string]string `json:"labels,omitempty"`

--- a/pkg/controllers/monitoring/options/options.go
+++ b/pkg/controllers/monitoring/options/options.go
@@ -7,13 +7,21 @@ import (
 )
 
 const (
-	ThanosDefaultImage                  = "thanosio/thanos:v0.25.2"
+	ThanosDefaultImage                  = "thanosio/thanos:v0.26.0"
 	EnvoyDefaultImage                   = "envoyproxy/envoy:v1.20.2"
-	PaodinMonitoringGatewayDefaultImage = "junotx/paodin-monitoring-gateway:latest"
+	PaodinMonitoringGatewayDefaultImage = "kubesphere/paodin-monitoring-gateway:latest"
 )
 
 var PrometheusConfigReloaderDefaultConfig = PrometheusConfigReloaderConfig{
 	Image:         "quay.io/prometheus-operator/prometheus-config-reloader:v0.55.1",
+	CPURequest:    "100m",
+	MemoryRequest: "50Mi",
+	CPULimit:      "100m",
+	MemoryLimit:   "50Mi",
+}
+
+var RulerQueryProxyDefaultConfig = RulerQueryProxyConfig{
+	Image:         PaodinMonitoringGatewayDefaultImage,
 	CPURequest:    "100m",
 	MemoryRequest: "50Mi",
 	CPULimit:      "100m",
@@ -51,12 +59,44 @@ func (o *PrometheusConfigReloaderConfig) ApplyTo(options *PrometheusConfigReload
 	}
 }
 
+type RulerQueryProxyConfig struct {
+	Image         string `json:"image,omitempty" yaml:"image,omitempty"`
+	CPURequest    string `json:"cpuRequest,omitempty" yaml:"cpuRequest,omitempty"`
+	MemoryRequest string `json:"memoryRequest,omitempty" yaml:"memoryRequest,omitempty"`
+	CPULimit      string `json:"cpuLimit,omitempty" yaml:"cpuRequest,omitempty"`
+	MemoryLimit   string `json:"memoryLimit,omitempty" yaml:"memoryLimit,omitempty"`
+}
+
+func (o *RulerQueryProxyConfig) Validate() []error {
+	var errs []error
+	return errs
+}
+
+func (o *RulerQueryProxyConfig) ApplyTo(options *PrometheusConfigReloaderConfig) {
+	if o.Image != "" {
+		options.Image = o.Image
+	}
+	if o.CPURequest != "" {
+		options.CPURequest = o.CPURequest
+	}
+	if o.MemoryRequest != "" {
+		options.MemoryRequest = o.MemoryRequest
+	}
+	if o.CPULimit != "" {
+		options.CPULimit = o.CPULimit
+	}
+	if o.MemoryLimit != "" {
+		options.MemoryLimit = o.MemoryLimit
+	}
+}
+
 type Options struct {
 	ThanosImage                  string `json:"thanosImage,omitempty" yaml:"thanosImage,omitempty"`
 	EnvoyImage                   string `json:"envoyImage,omitempty" yaml:"envoyImage,omitempty"`
 	PaodinMonitoringGatewayImage string `json:"paodinMonitoringGatewayImage,omitempty" yaml:"paodinMonitoringGatewayImage,omitempty"`
 
 	PrometheusConfigReloader PrometheusConfigReloaderConfig `json:"prometheusConfigReloader,omitempty" yaml:"prometheusConfigReloader,omitempty"`
+	RulerQueryProxy          RulerQueryProxyConfig          `json:"rulerQueryProxy,omitempty" yaml:"rulerQueryProxy,omitempty"`
 }
 
 func NewOptions() *Options {
@@ -65,6 +105,7 @@ func NewOptions() *Options {
 		EnvoyImage:                   EnvoyDefaultImage,
 		PaodinMonitoringGatewayImage: PaodinMonitoringGatewayDefaultImage,
 		PrometheusConfigReloader:     PrometheusConfigReloaderDefaultConfig,
+		RulerQueryProxy:              RulerQueryProxyDefaultConfig,
 	}
 }
 
@@ -102,4 +143,15 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, c *Options) {
 		PrometheusConfigReloaderDefaultConfig.MemoryRequest, "Prometheus Config Reloader Memory request. Value \"0\" disables it and causes no request to be configured.")
 	flag.StringVar(&c.PrometheusConfigReloader.MemoryLimit, "prometheus-config-reloader-memory-limit",
 		PrometheusConfigReloaderDefaultConfig.MemoryLimit, "Prometheus Config Reloader Memory limit. Value \"0\" disables it and causes no limit to be configured.")
+
+	flag.StringVar(&c.RulerQueryProxy.Image, "ruler-query-proxy-image",
+		RulerQueryProxyDefaultConfig.Image, "Ruler Query Proxy image with tag/version")
+	flag.StringVar(&c.RulerQueryProxy.CPURequest, "ruler-query-proxy-cpu-request",
+		RulerQueryProxyDefaultConfig.CPURequest, "Ruler Query Proxy CPU request. Value \"0\" disables it and causes no request to be configured.")
+	flag.StringVar(&c.RulerQueryProxy.CPULimit, "ruler-query-proxy-cpu-limit",
+		RulerQueryProxyDefaultConfig.CPULimit, "Ruler Query Proxy CPU limit. Value \"0\" disables it and causes no limit to be configured.")
+	flag.StringVar(&c.RulerQueryProxy.MemoryRequest, "ruler-query-proxy-memory-request",
+		RulerQueryProxyDefaultConfig.MemoryRequest, "Ruler Query Proxy Memory request. Value \"0\" disables it and causes no request to be configured.")
+	flag.StringVar(&c.RulerQueryProxy.MemoryLimit, "ruler-query-proxy-memory-limit",
+		RulerQueryProxyDefaultConfig.MemoryLimit, "Ruler Query Proxy Memory limit. Value \"0\" disables it and causes no limit to be configured.")
 }

--- a/pkg/controllers/monitoring/resources/common.go
+++ b/pkg/controllers/monitoring/resources/common.go
@@ -36,10 +36,6 @@ const (
 	LableNameAppInstance  = "app.kubernetes.io/instance"
 	LabelNameAppManagedBy = "app.kubernetes.io/managed-by"
 	LabelNameAppPartOf    = "app.kubernetes.io/part-of"
-
-	LabelNamePaodinPreprocessedDataIngestor = "monitoring.paodin.io/preprocessed-data-ingestor"
-
-	PseudoTenantDefaultId = "__pseudo_id"
 )
 
 func QualifiedName(appName, instanceName string, suffix ...string) string {
@@ -48,10 +44,6 @@ func QualifiedName(appName, instanceName string, suffix ...string) string {
 		name += "-" + strings.Join(suffix, "-")
 	}
 	return name
-}
-
-func PseudoTenantLabelName(tenantLabelName string) string {
-	return "__pseudo_" + tenantLabelName
 }
 
 func ThanosDefaultLivenessProbe() *corev1.Probe {

--- a/pkg/controllers/monitoring/resources/query/deployment.go
+++ b/pkg/controllers/monitoring/resources/query/deployment.go
@@ -97,7 +97,6 @@ func (q *Query) deployment() (runtime.Object, resources.Operation, error) {
 	for _, labelName := range q.query.ReplicaLabelNames {
 		queryContainer.Args = append(queryContainer.Args, "--query.replica-label="+labelName)
 	}
-	queryContainer.Args = append(queryContainer.Args, "--query.replica-label="+resources.PseudoTenantLabelName(q.Service.Spec.TenantLabelName))
 
 	var rulerList monitoringv1alpha1.ThanosRulerList
 	if err := q.Client.List(q.Context, &rulerList,

--- a/pkg/controllers/monitoring/resources/receive_ingestor/statefulset.go
+++ b/pkg/controllers/monitoring/resources/receive_ingestor/statefulset.go
@@ -187,15 +187,7 @@ func (r *ReceiveIngestor) statefulSet() (runtime.Object, resources.Operation, er
 				container.Args = append(container.Args, "--receive.tenant-header="+service.Spec.TenantHeader)
 			}
 			if service.Spec.TenantLabelName != "" {
-				var setPseudo bool
-				if r.ingestor.Labels != nil {
-					_, setPseudo = r.ingestor.Labels[resources.LabelNamePaodinPreprocessedDataIngestor]
-				}
-				if setPseudo {
-					container.Args = append(container.Args, "--receive.tenant-label-name="+resources.PseudoTenantLabelName(service.Spec.TenantLabelName))
-				} else {
-					container.Args = append(container.Args, "--receive.tenant-label-name="+service.Spec.TenantLabelName)
-				}
+				container.Args = append(container.Args, "--receive.tenant-label-name="+service.Spec.TenantLabelName)
 			}
 			if service.Spec.DefaultTenantId != "" {
 				container.Args = append(container.Args, "--receive.default-tenant-id="+service.Spec.DefaultTenantId)

--- a/pkg/controllers/monitoring/resources/ruler/ruler.go
+++ b/pkg/controllers/monitoring/resources/ruler/ruler.go
@@ -21,16 +21,19 @@ const (
 
 type Ruler struct {
 	resources.BaseReconciler
-	ruler          *monitoringv1alpha1.ThanosRuler
-	reloaderConfig options.PrometheusConfigReloaderConfig
+	ruler                 *monitoringv1alpha1.ThanosRuler
+	reloaderConfig        options.PrometheusConfigReloaderConfig
+	rulerQueryProxyConfig options.RulerQueryProxyConfig
 }
 
 func New(reconciler resources.BaseReconciler, ruler *monitoringv1alpha1.ThanosRuler,
-	reloaderConfig options.PrometheusConfigReloaderConfig) *Ruler {
+	reloaderConfig options.PrometheusConfigReloaderConfig, rulerQueryProxyConfig options.RulerQueryProxyConfig) *Ruler {
+
 	return &Ruler{
-		BaseReconciler: reconciler,
-		ruler:          ruler,
-		reloaderConfig: reloaderConfig,
+		BaseReconciler:        reconciler,
+		ruler:                 ruler,
+		reloaderConfig:        reloaderConfig,
+		rulerQueryProxyConfig: rulerQueryProxyConfig,
 	}
 }
 
@@ -96,7 +99,6 @@ func (r *Ruler) Reconcile() error {
 		ruleConfigMapNames = append(ruleConfigMapNames, cm.Name)
 	}
 
-	ress = append(ress, r.remoteWriteConfigMap)
 	ress = append(ress, func() (runtime.Object, resources.Operation, error) {
 		return r.statefulSet(ruleConfigMapNames)
 	})

--- a/pkg/controllers/monitoring/thanos_ruler_controller.go
+++ b/pkg/controllers/monitoring/thanos_ruler_controller.go
@@ -42,8 +42,9 @@ import (
 
 // ThanosRulerReconciler reconciles a ThanosRuler object
 type ThanosRulerReconciler struct {
-	DefaulterValidator ThanosRulerDefaulterValidator
-	ReloaderConfig     options.PrometheusConfigReloaderConfig
+	DefaulterValidator   ThanosRulerDefaulterValidator
+	ReloaderConfig       options.PrometheusConfigReloaderConfig
+	RulerQueryProxyConfig options.RulerQueryProxyConfig
 	client.Client
 	Scheme  *runtime.Scheme
 	Context context.Context
@@ -94,7 +95,7 @@ func (r *ThanosRulerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		Context: ctx,
 	}
 
-	if err := ruler.New(baseReconciler, instance, r.ReloaderConfig).Reconcile(); err != nil {
+	if err := ruler.New(baseReconciler, instance, r.ReloaderConfig, r.RulerQueryProxyConfig).Reconcile(); err != nil {
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
It supports the ruler to preprocess data for specified tenant. 

If the ruler is configured with a tenant and selects some recording rules,  it will evaluate recording rules against the data from its query proxy sidecar for the configured tenant, then remote write out resulting data with a request header named for the corresponding tenant.

If no tenant configured, the ruler will evaluate rules against data for all tenants.