### PR TITLE
refactor paodin to whizard

### DIFF
--- a/.github/workflows/build-cm-image.yaml
+++ b/.github/workflows/build-cm-image.yaml
@@ -63,4 +63,4 @@ jobs:
         run: |
           tag=$(cat VERSION | tr -d " \t\n\r")
           make docker-build-controller-manager -e REPO=${{ env.REPO }} -e TAG=$tag
-          docker push ${{ env.REPO }}/paodin-controller-manager:$tag
+          docker push ${{ env.REPO }}/whizard-controller-manager:$tag

--- a/.github/workflows/build-map-image.yaml
+++ b/.github/workflows/build-map-image.yaml
@@ -63,4 +63,4 @@ jobs:
         run: |
           tag=$(cat VERSION | tr -d " \t\n\r")
           make docker-build-monitoring-agent-proxy -e REPO=${{ env.REPO }} -e TAG=$tag
-          docker push ${{ env.REPO }}/paodin-monitoring-agent-proxy:$tag
+          docker push ${{ env.REPO }}/whizard-monitoring-agent-proxy:$tag

--- a/.github/workflows/build-mg-image.yaml
+++ b/.github/workflows/build-mg-image.yaml
@@ -63,4 +63,4 @@ jobs:
         run: |
           tag=$(cat VERSION | tr -d " \t\n\r")
           make docker-build-monitoring-gateway -e REPO=${{ env.REPO }} -e TAG=$tag
-          docker push ${{ env.REPO }}/paodin-monitoring-gateway:$tag
+          docker push ${{ env.REPO }}/whizard-monitoring-gateway:$tag

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 REPO ?= kubesphere
 TAG ?= latest
 
-CONTROLLER_MANAGER_IMG=${REPO}/paodin-controller-manager:${TAG}
-MONITORING_GATEWAY_IMG=${REPO}/paodin-monitoring-gateway:${TAG}
-MONITORING_AGENT_PROXY_IMG=${REPO}/paodin-monitoring-agent-proxy:${TAG}
+CONTROLLER_MANAGER_IMG=${REPO}/whizard-controller-manager:${TAG}
+MONITORING_GATEWAY_IMG=${REPO}/whizard-monitoring-gateway:${TAG}
+MONITORING_AGENT_PROXY_IMG=${REPO}/whizard-monitoring-agent-proxy:${TAG}
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 
@@ -116,14 +116,14 @@ bundle: manifests kustomize
 
 MONITORING_TYPE_GOES=$(shell find pkg/api/monitoring -name *_types.go | tr '\n' ' ')
 docs/monitoring/api.md: tools/docgen/docgen.go $(TYPE_GOES)
-	go run github.com/kubesphere/paodin/tools/docgen $(MONITORING_TYPE_GOES) > docs/monitoring/api.md
+	go run github.com/kubesphere/whizard/tools/docgen $(MONITORING_TYPE_GOES) > docs/monitoring/api.md
 
-paodin.key:
-	openssl genrsa -des3 -passout pass:x -out paodin.pass.key 2048
-	openssl rsa -passin pass:x -in paodin.pass.key -out paodin.key
-	rm paodin.pass.key
+whizard.key:
+	openssl genrsa -des3 -passout pass:x -out whizard.pass.key 2048
+	openssl rsa -passin pass:x -in whizard.pass.key -out whizard.key
+	rm whizard.pass.key
 
-paodin.crt: paodin.key
-	openssl req -new -key paodin.key -out paodin.csr
-	openssl x509 -req -sha256 -days 365 -in paodin.csr -signkey paodin.key -out paodin.crt
-	rm paodin.csr
+whizard.crt: whizard.key
+	openssl req -new -key whizard.key -out whizard.csr
+	openssl x509 -req -sha256 -days 365 -in whizard.csr -signkey whizard.key -out whizard.crt
+	rm whizard.csr

--- a/PROJECT
+++ b/PROJECT
@@ -1,25 +1,25 @@
-domain: paodin.io
+domain: whizard.io
 layout:
 - go.kubebuilder.io/v3
-projectName: paodin
-repo: github.com/kubesphere/paodin
+projectName: whizard
+repo: github.com/kubesphere/whizard
 resources:
 - api:
     crdVersion: v1
     namespaced: true
   controller: true
-  domain: paodin.io
+  domain: whizard.io
   group: monitoring
   kind: Service
-  path: github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1
+  path: github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
     namespaced: true
   controller: false
-  domain: paodin.io
+  domain: whizard.io
   group: monitoring
   kind: Agent
-  path: github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1
+  path: github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1
   version: v1alpha1
 version: "3"

--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
-# Paodin
+# Whizard
 
-Paodin is an observability platform for Kubernetes infrastructure and applications, which integrates your metrics, logs, events and so on accross kubernetes clusters.
+Whizard is an observability platform for Kubernetes infrastructure and applications, which integrates your metrics, logs, events and so on accross kubernetes clusters.
 
 ## Status
 
 | Component | Function | Status | Comment
 |--------|-----------|--------|--------|
-| *paodin-controller-manager*  | `Service` (CRD) |  | Define one Service instance, which contains *monitoring-gateway*, *Thanos Query* and *Thanos Receive Router* to handle and route metric read and write requests.
-|| `ThanosReceiveIngestor` (CRD) |  | Define one *Thanos Receive Ingestor* instance which lands metric data.
-|| `Store` (CRD) |  | Define one Store instace, which contains *Thanos Store Gateway* and *Thanos Compact* for long term storage.
-|| `ThanosRuler` (CRD) | | Define one *Thanos Ruler* instance.
+| *whizard-controller-manager*  | `Service` (CRD) |  | Define one Service instance, which contains *monitoring-gateway*, *Query* and *Router* to handle and route metric read and write requests.
+|| `Ingester` (CRD) |  | Define one *Receive Ingester* instance which lands metric data.
+|| `Store` (CRD) |  | Define one Store instace for long term storage.
+|| `Ruler` (CRD) | | Define one *Ruler* instance.
 || `AlertingRule` (CRD) | | Define one single alerting rule.
 || `RuleGroup` (CRD) | | Define one rule group.
 | *monitoring-gateway* | Auth/Proxy for monitoring service |  |
 | *monitoring-agent-proxy* | Proxy for prometheus agent
-| *paodin-apiserver* |
+| *whizard-apiserver* |
 
 ## Install
 
-- Install paodin-controller-manager:
+- Install whizard-controller-manager:
 
     ```shell
-    kubectl apply -f https://raw.githubusercontent.com/kubesphere/paodin/master/config/bundle.yaml
+    kubectl apply -f https://raw.githubusercontent.com/kubesphere/whizard/master/config/bundle.yaml
     ```
 
 - See [here](./docs/monitoring/examples.md) to deploy your monitoring service accross clusters.

--- a/cmd/controller-manager/app/controllers.go
+++ b/cmd/controller-manager/app/controllers.go
@@ -2,17 +2,17 @@ package app
 
 import (
 	"context"
+
+	"github.com/kubesphere/whizard/cmd/controller-manager/app/options"
+	"github.com/kubesphere/whizard/pkg/client/k8s"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring"
+	"github.com/kubesphere/whizard/pkg/informers"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-
-	"github.com/kubesphere/paodin/cmd/controller-manager/app/options"
-	"github.com/kubesphere/paodin/pkg/client/k8s"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring"
-	"github.com/kubesphere/paodin/pkg/informers"
 )
 
 func addControllers(mgr manager.Manager, client k8s.Client, informerFactory informers.InformerFactory,
-	cmOptions *options.PaodinControllerManagerOptions, ctx context.Context) error {
+	cmOptions *options.ControllerManagerOptions, ctx context.Context) error {
 
 	if err := (&monitoring.ServiceReconciler{
 		DefaulterValidator: monitoring.CreateServiceDefaulterValidator(*cmOptions.MonitoringOptions),

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -10,12 +10,12 @@ import (
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2"
 
-	"github.com/kubesphere/paodin/pkg/client/k8s"
-	"github.com/kubesphere/paodin/pkg/controllers/config"
-	monitoring "github.com/kubesphere/paodin/pkg/controllers/monitoring/options"
+	"github.com/kubesphere/whizard/pkg/client/k8s"
+	"github.com/kubesphere/whizard/pkg/controllers/config"
+	monitoring "github.com/kubesphere/whizard/pkg/controllers/monitoring/options"
 )
 
-type PaodinControllerManagerOptions struct {
+type ControllerManagerOptions struct {
 	KubernetesOptions *k8s.KubernetesOptions
 	MonitoringOptions *monitoring.Options
 
@@ -27,8 +27,8 @@ type PaodinControllerManagerOptions struct {
 	HealthProbeBindAddress string
 }
 
-func NewPaodinControllerManagerOptions() *PaodinControllerManagerOptions {
-	return &PaodinControllerManagerOptions{
+func NewControllerManagerOptions() *ControllerManagerOptions {
+	return &ControllerManagerOptions{
 		KubernetesOptions: k8s.NewKubernetesOptions(),
 		MonitoringOptions: monitoring.NewOptions(),
 
@@ -45,7 +45,7 @@ func NewPaodinControllerManagerOptions() *PaodinControllerManagerOptions {
 	}
 }
 
-func (s *PaodinControllerManagerOptions) Flags() cliflag.NamedFlagSets {
+func (s *ControllerManagerOptions) Flags() cliflag.NamedFlagSets {
 	fss := cliflag.NamedFlagSets{}
 	s.KubernetesOptions.AddFlags(fss.FlagSet("kubernetes"), s.KubernetesOptions)
 	s.MonitoringOptions.AddFlags(fss.FlagSet("monitoring"), s.MonitoringOptions)
@@ -77,14 +77,14 @@ func (s *PaodinControllerManagerOptions) Flags() cliflag.NamedFlagSets {
 	return fss
 }
 
-func (s *PaodinControllerManagerOptions) Validate() []error {
+func (s *ControllerManagerOptions) Validate() []error {
 	var errs []error
 	errs = append(errs, s.KubernetesOptions.Validate()...)
 	errs = append(errs, s.MonitoringOptions.Validate()...)
 	return errs
 }
 
-func (s *PaodinControllerManagerOptions) bindLeaderElectionFlags(l *leaderelection.LeaderElectionConfig, fs *pflag.FlagSet) {
+func (s *ControllerManagerOptions) bindLeaderElectionFlags(l *leaderelection.LeaderElectionConfig, fs *pflag.FlagSet) {
 	fs.DurationVar(&l.LeaseDuration, "leader-elect-lease-duration", l.LeaseDuration, ""+
 		"The duration that non-leader candidates will wait after observing a leadership "+
 		"renewal until attempting to acquire leadership of a led but unrenewed leader "+
@@ -102,7 +102,7 @@ func (s *PaodinControllerManagerOptions) bindLeaderElectionFlags(l *leaderelecti
 
 // MergeConfig merge new config without validation
 // When misconfigured, the app should just crash directly
-func (s *PaodinControllerManagerOptions) MergeConfig(cfg *config.Config) {
+func (s *ControllerManagerOptions) MergeConfig(cfg *config.Config) {
 	if cfg.KubernetesOptions != nil {
 		cfg.KubernetesOptions.ApplyTo(s.KubernetesOptions)
 	}

--- a/cmd/controller-manager/app/server.go
+++ b/cmd/controller-manager/app/server.go
@@ -18,21 +18,21 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
-	"github.com/kubesphere/paodin/cmd/controller-manager/app/options"
-	"github.com/kubesphere/paodin/pkg/apis"
-	"github.com/kubesphere/paodin/pkg/client/k8s"
-	"github.com/kubesphere/paodin/pkg/controllers/config"
-	"github.com/kubesphere/paodin/pkg/informers"
+	"github.com/kubesphere/whizard/cmd/controller-manager/app/options"
+	"github.com/kubesphere/whizard/pkg/apis"
+	"github.com/kubesphere/whizard/pkg/client/k8s"
+	"github.com/kubesphere/whizard/pkg/controllers/config"
+	"github.com/kubesphere/whizard/pkg/informers"
 	clusterv1alpha1 "kubesphere.io/api/cluster/v1alpha1"
 )
 
 func NewControllerManagerCommand() *cobra.Command {
-	// Here will create a default paodin controller manager options
-	s := options.NewPaodinControllerManagerOptions()
+	// Here will create a default whizard controller manager options
+	s := options.NewControllerManagerOptions()
 	conf, err := config.TryLoadFromDisk()
 	if err == nil {
 		// make sure LeaderElection is not nil
-		// override paodin controller manager options
+		// override whizard controller manager options
 		if conf.KubernetesOptions != nil {
 			conf.KubernetesOptions.ApplyTo(s.KubernetesOptions)
 		}
@@ -47,7 +47,7 @@ func NewControllerManagerCommand() *cobra.Command {
 	// Initialize command to run our controllers later
 	cmd := &cobra.Command{
 		Use:   "controller-manager",
-		Short: `Paodin controller manager`,
+		Short: `Whizard controller manager`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if errs := s.Validate(); len(errs) != 0 {
 				klog.Error(utilerrors.NewAggregate(errs))
@@ -77,7 +77,7 @@ func NewControllerManagerCommand() *cobra.Command {
 
 	versionCmd := &cobra.Command{
 		Use:   "version",
-		Short: "Print the version of Paodin controller",
+		Short: "Print the version of Whizard controller",
 		Run: func(cmd *cobra.Command, args []string) {
 			// cmd.Println(version.Get())
 		},
@@ -88,7 +88,7 @@ func NewControllerManagerCommand() *cobra.Command {
 	return cmd
 }
 
-func Run(s *options.PaodinControllerManagerOptions, configCh <-chan config.Config, ctx context.Context) error {
+func Run(s *options.ControllerManagerOptions, configCh <-chan config.Config, ctx context.Context) error {
 	ictx, cancelFunc := context.WithCancel(context.TODO())
 	errCh := make(chan error)
 	defer close(errCh)
@@ -122,7 +122,7 @@ func Run(s *options.PaodinControllerManagerOptions, configCh <-chan config.Confi
 	}
 }
 
-func run(s *options.PaodinControllerManagerOptions, ctx context.Context) error {
+func run(s *options.ControllerManagerOptions, ctx context.Context) error {
 	// Init k8s client
 	kubernetesClient, err := k8s.NewKubernetesClient(s.KubernetesOptions)
 	if err != nil {
@@ -145,7 +145,7 @@ func run(s *options.PaodinControllerManagerOptions, ctx context.Context) error {
 
 	if s.LeaderElect {
 		mgrOptions.LeaderElection = s.LeaderElect
-		mgrOptions.LeaderElectionID = "paodin-controller-manager-leader-election"
+		mgrOptions.LeaderElectionID = "whizard-controller-manager-leader-election"
 		mgrOptions.LeaseDuration = &s.LeaderElection.LeaseDuration
 		mgrOptions.RetryPeriod = &s.LeaderElection.RetryPeriod
 		mgrOptions.RenewDeadline = &s.LeaderElection.RenewDeadline

--- a/cmd/controller-manager/controller-manager.go
+++ b/cmd/controller-manager/controller-manager.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/kubesphere/paodin/cmd/controller-manager/app"
+	"github.com/kubesphere/whizard/cmd/controller-manager/app"
 )
 
 func main() {

--- a/cmd/monitoring-agent-proxy/monitoring-agent-proxy.go
+++ b/cmd/monitoring-agent-proxy/monitoring-agent-proxy.go
@@ -7,7 +7,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/logging"
 	thanos_tls "github.com/thanos-io/thanos/pkg/tls"
 
-	monitoringagentproxy "github.com/kubesphere/paodin/pkg/monitoring-agent-proxy"
+	monitoringagentproxy "github.com/kubesphere/whizard/pkg/monitoring-agent-proxy"
 )
 
 var cli struct {
@@ -22,7 +22,7 @@ var cli struct {
 	ServerTlsClientCa string `default:"" help:"TLS CA to verify clients against. If no client CA is specified, there is no client verification on server side. (tls.NoClientCert)"`
 
 	MonitorGateway struct {
-		Address            string `default:"" help:"Address to connect paodin monitor-gateway"`
+		Address            string `default:"" help:"Address to connect whizard monitor-gateway"`
 		ClientTlsKey       string `default:"" help:"TLS Key for HTTP client, leave blank to skip verify."`
 		ClientTlsCert      string `default:"" help:"TLS Certificate for HTTP client, leave blank to skip verify."`
 		ServerTlsClientCa  string `default:"" help:"TLS CA to verify clients against. If no client CA is specified, there is no client verification on server side. (tls.NoClientCert)"`

--- a/cmd/monitoring-gateway/monitoring-gateway.go
+++ b/cmd/monitoring-gateway/monitoring-gateway.go
@@ -8,7 +8,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/logging"
 	thanos_tls "github.com/thanos-io/thanos/pkg/tls"
 
-	monitoringgateway "github.com/kubesphere/paodin/pkg/monitoring-gateway"
+	monitoringgateway "github.com/kubesphere/whizard/pkg/monitoring-gateway"
 )
 
 var cli struct {
@@ -29,7 +29,7 @@ var cli struct {
 		Address string `default:"" help:"Address to send query requests."`
 	} `embed:"" prefix:"query."`
 	Tenant struct {
-		Header    string `default:"THANOS-TENANT" help:"Http header to determine tenant for requests"`
+		Header    string `default:"WHIZARD-TENANT" help:"Http header to determine tenant for requests"`
 		LabelName string `default:"tenant_id" help:"Label name through which the tenant will be announced"`
 	} `embed:"" prefix:"tenant."`
 }

--- a/config/bundle.yaml
+++ b/config/bundle.yaml
@@ -9,9 +9,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  name: compactors.monitoring.paodin.io
+  name: compactors.monitoring.whizard.io
 spec:
-  group: monitoring.paodin.io
+  group: monitoring.whizard.io
   names:
     kind: Compactor
     listKind: CompactorList
@@ -699,7 +699,7 @@ spec:
                 description: Flags is a list of key/value that could be used to set strategy parameters.
                 type: object
               image:
-                description: Image is the thanos image with tag/version
+                description: Image is the image with tag/version
                 type: string
               imagePullPolicy:
                 description: Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated.
@@ -814,9 +814,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  name: ingesters.monitoring.paodin.io
+  name: ingesters.monitoring.whizard.io
 spec:
-  group: monitoring.paodin.io
+  group: monitoring.whizard.io
   names:
     kind: Ingester
     listKind: IngesterList
@@ -1502,7 +1502,7 @@ spec:
                 description: Flags is a list of key/value that could be used to set strategy parameters.
                 type: object
               image:
-                description: Image is the thanos image with tag/version
+                description: Image is the image with tag/version
                 type: string
               localTsdbRetention:
                 description: LocalTsdbRetention configs how long to retain raw samples on local storage.
@@ -1602,9 +1602,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  name: rulegroups.monitoring.paodin.io
+  name: rulegroups.monitoring.whizard.io
 spec:
-  group: monitoring.paodin.io
+  group: monitoring.whizard.io
   names:
     kind: RuleGroup
     listKind: RuleGroupList
@@ -1654,9 +1654,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  name: rulers.monitoring.paodin.io
+  name: rulers.monitoring.whizard.io
 spec:
-  group: monitoring.paodin.io
+  group: monitoring.whizard.io
   names:
     kind: Ruler
     listKind: RulerList
@@ -2142,12 +2142,12 @@ spec:
                     type: object
                 type: object
               alertDropLabels:
-                description: AlertDropLabels configure the label names which should be dropped in Ruler alerts. The replica label `thanos_ruler_replica` will always be dropped in alerts.
+                description: AlertDropLabels configure the label names which should be dropped in Ruler alerts. The replica label `ruler_replica` will always be dropped in alerts.
                 items:
                   type: string
                 type: array
               alertmanagersConfig:
-                description: Define configuration for connecting to alertmanager.  Only available with thanos v0.10.0 and higher.  Maps to the `alertmanagers.config` arg.
+                description: Define configuration for connecting to alertmanager. Maps to the `alertmanagers.config` arg.
                 properties:
                   key:
                     description: The key of the secret to select from.  Must be a valid secret key.
@@ -2161,11 +2161,6 @@ spec:
                 required:
                 - key
                 type: object
-              alertmanagersUrl:
-                description: 'Define URLs to send alerts to Alertmanager.  For Thanos v0.10.0 and higher, AlertManagersConfig should be used instead.  Note: this field will be ignored if AlertManagersConfig is specified. Maps to the `alertmanagers.url` arg.'
-                items:
-                  type: string
-                type: array
               dataVolume:
                 description: DataVolume specifies how volume shall be used
                 properties:
@@ -2372,12 +2367,12 @@ spec:
                 description: Flags is a list of key/value that could be used to set strategy parameters.
                 type: object
               image:
-                description: Image is the thanos image with tag/version
+                description: Image is the image with tag/version
                 type: string
               labels:
                 additionalProperties:
                   type: string
-                description: Labels configure the external label pairs to Ruler. A default replica label `thanos_ruler_replica` will be always added  as a label with the value of the pod's name and it will be dropped in the alerts.
+                description: Labels configure the external label pairs to Ruler. A default replica label `ruler_replica` will be always added  as a label with the value of the pod's name and it will be dropped in the alerts.
                 type: object
               logFormat:
                 description: 'Log format to use. Possible options: logfmt or json'
@@ -2584,9 +2579,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  name: rules.monitoring.paodin.io
+  name: rules.monitoring.whizard.io
 spec:
-  group: monitoring.paodin.io
+  group: monitoring.whizard.io
   names:
     kind: Rule
     listKind: RuleList
@@ -2655,9 +2650,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  name: services.monitoring.paodin.io
+  name: services.monitoring.whizard.io
 spec:
-  group: monitoring.paodin.io
+  group: monitoring.whizard.io
   names:
     kind: Service
     listKind: ServiceList
@@ -2685,7 +2680,7 @@ spec:
                 description: Default tenant ID to use when none is provided via a header.
                 type: string
               gateway:
-                description: Gateway to proxy and auth requests to Query and Router defined in Thanos.
+                description: Gateway to proxy and auth requests to Query and Router.
                 properties:
                   affinity:
                     description: If specified, the pod's scheduling constraints.
@@ -3717,7 +3712,7 @@ spec:
                     description: Flags is a list of key/value that could be used to set strategy parameters.
                     type: object
                   image:
-                    description: Image is the thanos image with tag/version
+                    description: Image is the image with tag/version
                     type: string
                   logFormat:
                     description: 'Log format to use. Possible options: logfmt or json'
@@ -3771,7 +3766,7 @@ spec:
                     items:
                       properties:
                         addresses:
-                          description: Address is the addresses of StoreApi server, which may be prefixed with 'dns+' or 'dnssrv+' to detect StoreAPI servers through respective DNS lookups. For more info, see https://thanos.io/tip/thanos/service-discovery.md/#dns-service-discovery
+                          description: Address is the addresses of StoreApi server, which may be prefixed with 'dns+' or 'dnssrv+' to detect StoreAPI servers through respective DNS lookups.
                           items:
                             type: string
                           type: array
@@ -4312,7 +4307,7 @@ spec:
                     description: Flags is a list of key/value that could be used to set strategy parameters.
                     type: object
                   image:
-                    description: Image is the thanos image with tag/version
+                    description: Image is the image with tag/version
                     type: string
                   logFormat:
                     description: 'Log format to use. Possible options: logfmt or json'
@@ -4845,7 +4840,7 @@ spec:
                     description: Flags is a list of key/value that could be used to set strategy parameters.
                     type: object
                   image:
-                    description: Image is the thanos image with tag/version
+                    description: Image is the image with tag/version
                     type: string
                   logFormat:
                     description: 'Log format to use. Possible options: logfmt or json'
@@ -4947,9 +4942,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  name: storages.monitoring.paodin.io
+  name: storages.monitoring.whizard.io
 spec:
-  group: monitoring.paodin.io
+  group: monitoring.whizard.io
   names:
     kind: Storage
     listKind: StorageList
@@ -5121,9 +5116,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  name: stores.monitoring.paodin.io
+  name: stores.monitoring.whizard.io
 spec:
-  group: monitoring.paodin.io
+  group: monitoring.whizard.io
   names:
     kind: Store
     listKind: StoreList
@@ -5808,7 +5803,7 @@ spec:
                 description: Flags is a list of key/value that could be used to set strategy parameters.
                 type: object
               image:
-                description: Image is the thanos image with tag/version
+                description: Image is the image with tag/version
                 type: string
               imagePullPolicy:
                 description: Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated.
@@ -6329,9 +6324,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  name: tenants.monitoring.paodin.io
+  name: tenants.monitoring.whizard.io
 spec:
-  group: monitoring.paodin.io
+  group: monitoring.whizard.io
   names:
     kind: Tenant
     listKind: TenantList
@@ -6403,13 +6398,13 @@ status:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: paodin-controller-manager
+  name: whizard-controller-manager
   namespace: kubesphere-monitoring-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: paodin-leader-election-role
+  name: whizard-leader-election-role
   namespace: kubesphere-monitoring-system
 rules:
 - apiGroups:
@@ -6448,7 +6443,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: paodin-manager-role
+  name: whizard-manager-role
 rules:
 - apiGroups:
   - apps
@@ -6559,7 +6554,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - alertingrules
   verbs:
@@ -6567,7 +6562,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - compactors
   verbs:
@@ -6579,13 +6574,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - compactors/finalizers
   verbs:
   - update
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - compactors/status
   verbs:
@@ -6593,7 +6588,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - ingesters
   verbs:
@@ -6605,13 +6600,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - ingesters/finalizers
   verbs:
   - update
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - ingesters/status
   verbs:
@@ -6619,7 +6614,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - rulegroups
   verbs:
@@ -6627,7 +6622,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - rulers
   verbs:
@@ -6639,13 +6634,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - rulers/finalizers
   verbs:
   - update
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - rulers/status
   verbs:
@@ -6653,7 +6648,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - rules
   verbs:
@@ -6661,7 +6656,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - service
   verbs:
@@ -6669,7 +6664,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - services
   verbs:
@@ -6681,13 +6676,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - services/finalizers
   verbs:
   - update
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - services/status
   verbs:
@@ -6695,7 +6690,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - storage
   verbs:
@@ -6703,7 +6698,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - storages
   verbs:
@@ -6715,7 +6710,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - stores
   verbs:
@@ -6727,13 +6722,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - stores/finalizers
   verbs:
   - update
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - stores/status
   verbs:
@@ -6741,7 +6736,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - tenants
   verbs:
@@ -6754,13 +6749,13 @@ rules:
   - verbs=get
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - tenants/finalizers
   verbs:
   - update
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - tenants/status
   verbs:
@@ -6784,7 +6779,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: paodin-metrics-reader
+  name: whizard-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics
@@ -6794,7 +6789,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: paodin-proxy-role
+  name: whizard-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -6812,41 +6807,41 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: paodin-leader-election-rolebinding
+  name: whizard-leader-election-rolebinding
   namespace: kubesphere-monitoring-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: paodin-leader-election-role
+  name: whizard-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: paodin-controller-manager
+  name: whizard-controller-manager
   namespace: kubesphere-monitoring-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: paodin-manager-rolebinding
+  name: whizard-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: paodin-manager-role
+  name: whizard-manager-role
 subjects:
 - kind: ServiceAccount
-  name: paodin-controller-manager
+  name: whizard-controller-manager
   namespace: kubesphere-monitoring-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: paodin-proxy-rolebinding
+  name: whizard-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: paodin-proxy-role
+  name: whizard-proxy-role
 subjects:
 - kind: ServiceAccount
-  name: paodin-controller-manager
+  name: whizard-controller-manager
   namespace: kubesphere-monitoring-system
 ---
 apiVersion: v1
@@ -6862,10 +6857,10 @@ data:
       port: 9443
     leaderElection:
       leaderElect: true
-      resourceName: paodin-controller-manager-leader-election
+      resourceName: whizard-controller-manager-leader-election
 kind: ConfigMap
 metadata:
-  name: paodin-manager-config
+  name: whizard-manager-config
   namespace: kubesphere-monitoring-system
 ---
 apiVersion: v1
@@ -6873,7 +6868,7 @@ kind: Service
 metadata:
   labels:
     control-plane: controller-manager
-  name: paodin-controller-manager-metrics-service
+  name: whizard-controller-manager-metrics-service
   namespace: kubesphere-monitoring-system
 spec:
   ports:
@@ -6887,20 +6882,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: paodin-controller-manager
+    app: whizard-controller-manager
     control-plane: controller-manager
-  name: paodin-controller-manager
+  name: whizard-controller-manager
   namespace: kubesphere-monitoring-system
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: paodin-controller-manager
+      app: whizard-controller-manager
       control-plane: controller-manager
   template:
     metadata:
       labels:
-        app: paodin-controller-manager
+        app: whizard-controller-manager
         control-plane: controller-manager
     spec:
       containers:
@@ -6920,7 +6915,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: kubesphere/paodin-controller-manager:latest
+        image: kubesphere/whizard-controller-manager:latest
         livenessProbe:
           httpGet:
             path: /healthz
@@ -6945,5 +6940,5 @@ spec:
           allowPrivilegeEscalation: false
       securityContext:
         runAsNonRoot: true
-      serviceAccountName: paodin-controller-manager
+      serviceAccountName: whizard-controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/crd/bases/monitoring.whizard.io_compactors.yaml
+++ b/config/crd/bases/monitoring.whizard.io_compactors.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  name: compactors.monitoring.paodin.io
+  name: compactors.monitoring.whizard.io
 spec:
-  group: monitoring.paodin.io
+  group: monitoring.whizard.io
   names:
     kind: Compactor
     listKind: CompactorList
@@ -1176,7 +1176,7 @@ spec:
                   strategy parameters.
                 type: object
               image:
-                description: Image is the thanos image with tag/version
+                description: Image is the image with tag/version
                 type: string
               imagePullPolicy:
                 description: Image pull policy. One of Always, Never, IfNotPresent.

--- a/config/crd/bases/monitoring.whizard.io_ingesters.yaml
+++ b/config/crd/bases/monitoring.whizard.io_ingesters.yaml
@@ -6,20 +6,20 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  name: stores.monitoring.paodin.io
+  name: ingesters.monitoring.whizard.io
 spec:
-  group: monitoring.paodin.io
+  group: monitoring.whizard.io
   names:
-    kind: Store
-    listKind: StoreList
-    plural: stores
-    singular: store
+    kind: Ingester
+    listKind: IngesterList
+    plural: ingesters
+    singular: ingester
   scope: Namespaced
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Store is the Schema for the Store API
+        description: Ingester is the Schema for the Ingester API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -34,6 +34,7 @@ spec:
           metadata:
             type: object
           spec:
+            description: IngesterSpec defines the desired state of a Ingester
             properties:
               affinity:
                 description: If specified, the pod's scheduling constraints.
@@ -1173,26 +1174,12 @@ spec:
                   strategy parameters.
                 type: object
               image:
-                description: Image is the thanos image with tag/version
+                description: Image is the image with tag/version
                 type: string
-              imagePullPolicy:
-                description: Image pull policy. One of Always, Never, IfNotPresent.
-                  Defaults to Always if :latest tag is specified, or IfNotPresent
-                  otherwise. Cannot be updated.
+              localTsdbRetention:
+                description: LocalTsdbRetention configs how long to retain raw samples
+                  on local storage.
                 type: string
-              indexCacheConfig:
-                description: IndexCacheConfig contains index cache configuration.
-                properties:
-                  inMemory:
-                    properties:
-                      maxSize:
-                        description: MaxSize represents overall maximum number of
-                          bytes cache can contain.
-                        type: string
-                    required:
-                    - maxSize
-                    type: object
-                type: object
               logFormat:
                 description: 'Log format to use. Possible options: logfmt or json'
                 type: string
@@ -1200,19 +1187,13 @@ spec:
                 description: 'Log filtering level. Possible options: error, warn,
                   info, debug'
                 type: string
-              maxTime:
-                description: MaxTime specifies end of time range limit to serve
-                type: string
-              minTime:
-                description: MinTime specifies start of time range limit to serve
-                type: string
               nodeSelector:
                 additionalProperties:
                   type: string
                 description: Define which Nodes the Pods are scheduled on.
                 type: object
               replicas:
-                description: Number of replicas for a component
+                description: Number of replicas for a component.
                 format: int32
                 type: integer
               resources:
@@ -1241,642 +1222,21 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
-              scaler:
-                properties:
-                  behavior:
-                    description: behavior configures the scaling behavior of the target
-                      in both Up and Down directions (scaleUp and scaleDown fields
-                      respectively). If not set, the default HPAScalingRules for scale
-                      up and scale down are used.
-                    properties:
-                      scaleDown:
-                        description: scaleDown is scaling policy for scaling Down.
-                          If not set, the default value is to allow to scale down
-                          to minReplicas pods, with a 300 second stabilization window
-                          (i.e., the highest recommendation for the last 300sec is
-                          used).
-                        properties:
-                          policies:
-                            description: policies is a list of potential scaling polices
-                              which can be used during scaling. At least one policy
-                              must be specified, otherwise the HPAScalingRules will
-                              be discarded as invalid
-                            items:
-                              description: HPAScalingPolicy is a single policy which
-                                must hold true for a specified past interval.
-                              properties:
-                                periodSeconds:
-                                  description: PeriodSeconds specifies the window
-                                    of time for which the policy should hold true.
-                                    PeriodSeconds must be greater than zero and less
-                                    than or equal to 1800 (30 min).
-                                  format: int32
-                                  type: integer
-                                type:
-                                  description: Type is used to specify the scaling
-                                    policy.
-                                  type: string
-                                value:
-                                  description: Value contains the amount of change
-                                    which is permitted by the policy. It must be greater
-                                    than zero
-                                  format: int32
-                                  type: integer
-                              required:
-                              - periodSeconds
-                              - type
-                              - value
-                              type: object
-                            type: array
-                          selectPolicy:
-                            description: selectPolicy is used to specify which policy
-                              should be used. If not set, the default value MaxPolicySelect
-                              is used.
-                            type: string
-                          stabilizationWindowSeconds:
-                            description: 'StabilizationWindowSeconds is the number
-                              of seconds for which past recommendations should be
-                              considered while scaling up or scaling down. StabilizationWindowSeconds
-                              must be greater than or equal to zero and less than
-                              or equal to 3600 (one hour). If not set, use the default
-                              values: - For scale up: 0 (i.e. no stabilization is
-                              done). - For scale down: 300 (i.e. the stabilization
-                              window is 300 seconds long).'
-                            format: int32
-                            type: integer
-                        type: object
-                      scaleUp:
-                        description: 'scaleUp is scaling policy for scaling Up. If
-                          not set, the default value is the higher of:   * increase
-                          no more than 4 pods per 60 seconds   * double the number
-                          of pods per 60 seconds No stabilization is used.'
-                        properties:
-                          policies:
-                            description: policies is a list of potential scaling polices
-                              which can be used during scaling. At least one policy
-                              must be specified, otherwise the HPAScalingRules will
-                              be discarded as invalid
-                            items:
-                              description: HPAScalingPolicy is a single policy which
-                                must hold true for a specified past interval.
-                              properties:
-                                periodSeconds:
-                                  description: PeriodSeconds specifies the window
-                                    of time for which the policy should hold true.
-                                    PeriodSeconds must be greater than zero and less
-                                    than or equal to 1800 (30 min).
-                                  format: int32
-                                  type: integer
-                                type:
-                                  description: Type is used to specify the scaling
-                                    policy.
-                                  type: string
-                                value:
-                                  description: Value contains the amount of change
-                                    which is permitted by the policy. It must be greater
-                                    than zero
-                                  format: int32
-                                  type: integer
-                              required:
-                              - periodSeconds
-                              - type
-                              - value
-                              type: object
-                            type: array
-                          selectPolicy:
-                            description: selectPolicy is used to specify which policy
-                              should be used. If not set, the default value MaxPolicySelect
-                              is used.
-                            type: string
-                          stabilizationWindowSeconds:
-                            description: 'StabilizationWindowSeconds is the number
-                              of seconds for which past recommendations should be
-                              considered while scaling up or scaling down. StabilizationWindowSeconds
-                              must be greater than or equal to zero and less than
-                              or equal to 3600 (one hour). If not set, use the default
-                              values: - For scale up: 0 (i.e. no stabilization is
-                              done). - For scale down: 300 (i.e. the stabilization
-                              window is 300 seconds long).'
-                            format: int32
-                            type: integer
-                        type: object
-                    type: object
-                  maxReplicas:
-                    description: maxReplicas is the upper limit for the number of
-                      replicas to which the autoscaler can scale up. It cannot be
-                      less that minReplicas.
-                    format: int32
-                    type: integer
-                  metrics:
-                    description: metrics contains the specifications for which to
-                      use to calculate the desired replica count (the maximum replica
-                      count across all metrics will be used).  The desired replica
-                      count is calculated multiplying the ratio between the target
-                      value and the current value by the current number of pods.  Ergo,
-                      metrics used must decrease as the pod count is increased, and
-                      vice-versa.  See the individual metric source types for more
-                      information about how each type of metric must respond. If not
-                      set, the default metric will be set to 80% average CPU utilization.
-                    items:
-                      description: MetricSpec specifies how to scale based on a single
-                        metric (only `type` and one other matching field should be
-                        set at once).
-                      properties:
-                        containerResource:
-                          description: container resource refers to a resource metric
-                            (such as those specified in requests and limits) known
-                            to Kubernetes describing a single container in each pod
-                            of the current scale target (e.g. CPU or memory). Such
-                            metrics are built in to Kubernetes, and have special scaling
-                            options on top of those available to normal per-pod metrics
-                            using the "pods" source. This is an alpha feature and
-                            can be enabled by the HPAContainerMetrics feature flag.
-                          properties:
-                            container:
-                              description: container is the name of the container
-                                in the pods of the scaling target
-                              type: string
-                            name:
-                              description: name is the name of the resource in question.
-                              type: string
-                            target:
-                              description: target specifies the target value for the
-                                given metric
-                              properties:
-                                averageUtilization:
-                                  description: averageUtilization is the target value
-                                    of the average of the resource metric across all
-                                    relevant pods, represented as a percentage of
-                                    the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source
-                                    type
-                                  format: int32
-                                  type: integer
-                                averageValue:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: averageValue is the target value of
-                                    the average of the metric across all relevant
-                                    pods (as a quantity)
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type:
-                                  description: type represents whether the metric
-                                    type is Utilization, Value, or AverageValue
-                                  type: string
-                                value:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: value is the target value of the metric
-                                    (as a quantity).
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - type
-                              type: object
-                          required:
-                          - container
-                          - name
-                          - target
-                          type: object
-                        external:
-                          description: external refers to a global metric that is
-                            not associated with any Kubernetes object. It allows autoscaling
-                            based on information coming from components running outside
-                            of cluster (for example length of queue in cloud messaging
-                            service, or QPS from loadbalancer running outside of cluster).
-                          properties:
-                            metric:
-                              description: metric identifies the target metric by
-                                name and selector
-                              properties:
-                                name:
-                                  description: name is the name of the given metric
-                                  type: string
-                                selector:
-                                  description: selector is the string-encoded form
-                                    of a standard kubernetes label selector for the
-                                    given metric When set, it is passed as an additional
-                                    parameter to the metrics server for more specific
-                                    metrics scoping. When unset, just the metricName
-                                    will be used to gather metrics.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            target:
-                              description: target specifies the target value for the
-                                given metric
-                              properties:
-                                averageUtilization:
-                                  description: averageUtilization is the target value
-                                    of the average of the resource metric across all
-                                    relevant pods, represented as a percentage of
-                                    the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source
-                                    type
-                                  format: int32
-                                  type: integer
-                                averageValue:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: averageValue is the target value of
-                                    the average of the metric across all relevant
-                                    pods (as a quantity)
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type:
-                                  description: type represents whether the metric
-                                    type is Utilization, Value, or AverageValue
-                                  type: string
-                                value:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: value is the target value of the metric
-                                    (as a quantity).
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - type
-                              type: object
-                          required:
-                          - metric
-                          - target
-                          type: object
-                        object:
-                          description: object refers to a metric describing a single
-                            kubernetes object (for example, hits-per-second on an
-                            Ingress object).
-                          properties:
-                            describedObject:
-                              description: CrossVersionObjectReference contains enough
-                                information to let you identify the referred resource.
-                              properties:
-                                apiVersion:
-                                  description: API version of the referent
-                                  type: string
-                                kind:
-                                  description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
-                                  type: string
-                                name:
-                                  description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                                  type: string
-                              required:
-                              - kind
-                              - name
-                              type: object
-                            metric:
-                              description: metric identifies the target metric by
-                                name and selector
-                              properties:
-                                name:
-                                  description: name is the name of the given metric
-                                  type: string
-                                selector:
-                                  description: selector is the string-encoded form
-                                    of a standard kubernetes label selector for the
-                                    given metric When set, it is passed as an additional
-                                    parameter to the metrics server for more specific
-                                    metrics scoping. When unset, just the metricName
-                                    will be used to gather metrics.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            target:
-                              description: target specifies the target value for the
-                                given metric
-                              properties:
-                                averageUtilization:
-                                  description: averageUtilization is the target value
-                                    of the average of the resource metric across all
-                                    relevant pods, represented as a percentage of
-                                    the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source
-                                    type
-                                  format: int32
-                                  type: integer
-                                averageValue:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: averageValue is the target value of
-                                    the average of the metric across all relevant
-                                    pods (as a quantity)
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type:
-                                  description: type represents whether the metric
-                                    type is Utilization, Value, or AverageValue
-                                  type: string
-                                value:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: value is the target value of the metric
-                                    (as a quantity).
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - type
-                              type: object
-                          required:
-                          - describedObject
-                          - metric
-                          - target
-                          type: object
-                        pods:
-                          description: pods refers to a metric describing each pod
-                            in the current scale target (for example, transactions-processed-per-second).  The
-                            values will be averaged together before being compared
-                            to the target value.
-                          properties:
-                            metric:
-                              description: metric identifies the target metric by
-                                name and selector
-                              properties:
-                                name:
-                                  description: name is the name of the given metric
-                                  type: string
-                                selector:
-                                  description: selector is the string-encoded form
-                                    of a standard kubernetes label selector for the
-                                    given metric When set, it is passed as an additional
-                                    parameter to the metrics server for more specific
-                                    metrics scoping. When unset, just the metricName
-                                    will be used to gather metrics.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            target:
-                              description: target specifies the target value for the
-                                given metric
-                              properties:
-                                averageUtilization:
-                                  description: averageUtilization is the target value
-                                    of the average of the resource metric across all
-                                    relevant pods, represented as a percentage of
-                                    the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source
-                                    type
-                                  format: int32
-                                  type: integer
-                                averageValue:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: averageValue is the target value of
-                                    the average of the metric across all relevant
-                                    pods (as a quantity)
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type:
-                                  description: type represents whether the metric
-                                    type is Utilization, Value, or AverageValue
-                                  type: string
-                                value:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: value is the target value of the metric
-                                    (as a quantity).
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - type
-                              type: object
-                          required:
-                          - metric
-                          - target
-                          type: object
-                        resource:
-                          description: resource refers to a resource metric (such
-                            as those specified in requests and limits) known to Kubernetes
-                            describing each pod in the current scale target (e.g.
-                            CPU or memory). Such metrics are built in to Kubernetes,
-                            and have special scaling options on top of those available
-                            to normal per-pod metrics using the "pods" source.
-                          properties:
-                            name:
-                              description: name is the name of the resource in question.
-                              type: string
-                            target:
-                              description: target specifies the target value for the
-                                given metric
-                              properties:
-                                averageUtilization:
-                                  description: averageUtilization is the target value
-                                    of the average of the resource metric across all
-                                    relevant pods, represented as a percentage of
-                                    the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source
-                                    type
-                                  format: int32
-                                  type: integer
-                                averageValue:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: averageValue is the target value of
-                                    the average of the metric across all relevant
-                                    pods (as a quantity)
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type:
-                                  description: type represents whether the metric
-                                    type is Utilization, Value, or AverageValue
-                                  type: string
-                                value:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: value is the target value of the metric
-                                    (as a quantity).
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - type
-                              type: object
-                          required:
-                          - name
-                          - target
-                          type: object
-                        type:
-                          description: 'type is the type of metric source.  It should
-                            be one of "ContainerResource", "External", "Object", "Pods"
-                            or "Resource", each mapping to a matching field in the
-                            object. Note: "ContainerResource" type is available on
-                            when the feature-gate HPAContainerMetrics is enabled'
-                          type: string
-                      required:
-                      - type
-                      type: object
-                    type: array
-                  minReplicas:
-                    description: minReplicas is the lower limit for the number of
-                      replicas to which the autoscaler can scale down.  It defaults
-                      to 1 pod.  minReplicas is allowed to be 0 if the alpha feature
-                      gate HPAScaleToZero is enabled and at least one Object or External
-                      metric is configured.  Scaling is active as long as at least
-                      one metric value is available.
-                    format: int32
-                    type: integer
-                required:
-                - maxReplicas
-                type: object
               storage:
+                description: If specified, the object key of Storage for long term
+                  storage.
                 properties:
                   name:
                     type: string
                   namespace:
                     type: string
                 type: object
+              tenants:
+                description: Tenants if not empty indicates current config is for
+                  hard tenants; otherwise, it is for soft tenants.
+                items:
+                  type: string
+                type: array
               tolerations:
                 description: If specified, the pod's tolerations.
                 items:
@@ -1919,7 +1279,7 @@ spec:
                 type: array
             type: object
           status:
-            description: StoreStatus defines the observed state of Store
+            description: IngesterStatus defines the observed state of Ingester
             type: object
         type: object
     served: true

--- a/config/crd/bases/monitoring.whizard.io_rulegroups.yaml
+++ b/config/crd/bases/monitoring.whizard.io_rulegroups.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  name: rulegroups.monitoring.paodin.io
+  name: rulegroups.monitoring.whizard.io
 spec:
-  group: monitoring.paodin.io
+  group: monitoring.whizard.io
   names:
     kind: RuleGroup
     listKind: RuleGroupList

--- a/config/crd/bases/monitoring.whizard.io_rulers.yaml
+++ b/config/crd/bases/monitoring.whizard.io_rulers.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  name: rulers.monitoring.paodin.io
+  name: rulers.monitoring.whizard.io
 spec:
-  group: monitoring.paodin.io
+  group: monitoring.whizard.io
   names:
     kind: Ruler
     listKind: RulerList
@@ -863,15 +863,14 @@ spec:
                 type: object
               alertDropLabels:
                 description: AlertDropLabels configure the label names which should
-                  be dropped in Ruler alerts. The replica label `thanos_ruler_replica`
-                  will always be dropped in alerts.
+                  be dropped in Ruler alerts. The replica label `ruler_replica` will
+                  always be dropped in alerts.
                 items:
                   type: string
                 type: array
               alertmanagersConfig:
-                description: Define configuration for connecting to alertmanager.  Only
-                  available with thanos v0.10.0 and higher.  Maps to the `alertmanagers.config`
-                  arg.
+                description: Define configuration for connecting to alertmanager.
+                  Maps to the `alertmanagers.config` arg.
                 properties:
                   key:
                     description: The key of the secret to select from.  Must be a
@@ -887,14 +886,6 @@ spec:
                 required:
                 - key
                 type: object
-              alertmanagersUrl:
-                description: 'Define URLs to send alerts to Alertmanager.  For Thanos
-                  v0.10.0 and higher, AlertManagersConfig should be used instead.  Note:
-                  this field will be ignored if AlertManagersConfig is specified.
-                  Maps to the `alertmanagers.url` arg.'
-                items:
-                  type: string
-                type: array
               dataVolume:
                 description: DataVolume specifies how volume shall be used
                 properties:
@@ -1213,15 +1204,15 @@ spec:
                   strategy parameters.
                 type: object
               image:
-                description: Image is the thanos image with tag/version
+                description: Image is the image with tag/version
                 type: string
               labels:
                 additionalProperties:
                   type: string
                 description: Labels configure the external label pairs to Ruler. A
-                  default replica label `thanos_ruler_replica` will be always added  as
-                  a label with the value of the pod's name and it will be dropped
-                  in the alerts.
+                  default replica label `ruler_replica` will be always added  as a
+                  label with the value of the pod's name and it will be dropped in
+                  the alerts.
                 type: object
               logFormat:
                 description: 'Log format to use. Possible options: logfmt or json'

--- a/config/crd/bases/monitoring.whizard.io_rules.yaml
+++ b/config/crd/bases/monitoring.whizard.io_rules.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  name: rules.monitoring.paodin.io
+  name: rules.monitoring.whizard.io
 spec:
-  group: monitoring.paodin.io
+  group: monitoring.whizard.io
   names:
     kind: Rule
     listKind: RuleList

--- a/config/crd/bases/monitoring.whizard.io_services.yaml
+++ b/config/crd/bases/monitoring.whizard.io_services.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  name: services.monitoring.paodin.io
+  name: services.monitoring.whizard.io
 spec:
-  group: monitoring.paodin.io
+  group: monitoring.whizard.io
   names:
     kind: Service
     listKind: ServiceList
@@ -41,8 +41,7 @@ spec:
                   header.
                 type: string
               gateway:
-                description: Gateway to proxy and auth requests to Query and Router
-                  defined in Thanos.
+                description: Gateway to proxy and auth requests to Query and Router.
                 properties:
                   affinity:
                     description: If specified, the pod's scheduling constraints.
@@ -1916,7 +1915,7 @@ spec:
                       set strategy parameters.
                     type: object
                   image:
-                    description: Image is the thanos image with tag/version
+                    description: Image is the image with tag/version
                     type: string
                   logFormat:
                     description: 'Log format to use. Possible options: logfmt or json'
@@ -1979,8 +1978,7 @@ spec:
                         addresses:
                           description: Address is the addresses of StoreApi server,
                             which may be prefixed with 'dns+' or 'dnssrv+' to detect
-                            StoreAPI servers through respective DNS lookups. For more
-                            info, see https://thanos.io/tip/thanos/service-discovery.md/#dns-service-discovery
+                            StoreAPI servers through respective DNS lookups.
                           items:
                             type: string
                           type: array
@@ -2953,7 +2951,7 @@ spec:
                       set strategy parameters.
                     type: object
                   image:
-                    description: Image is the thanos image with tag/version
+                    description: Image is the image with tag/version
                     type: string
                   logFormat:
                     description: 'Log format to use. Possible options: logfmt or json'
@@ -3915,7 +3913,7 @@ spec:
                       set strategy parameters.
                     type: object
                   image:
-                    description: Image is the thanos image with tag/version
+                    description: Image is the image with tag/version
                     type: string
                   logFormat:
                     description: 'Log format to use. Possible options: logfmt or json'

--- a/config/crd/bases/monitoring.whizard.io_storages.yaml
+++ b/config/crd/bases/monitoring.whizard.io_storages.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  name: storages.monitoring.paodin.io
+  name: storages.monitoring.whizard.io
 spec:
-  group: monitoring.paodin.io
+  group: monitoring.whizard.io
   names:
     kind: Storage
     listKind: StorageList

--- a/config/crd/bases/monitoring.whizard.io_stores.yaml
+++ b/config/crd/bases/monitoring.whizard.io_stores.yaml
@@ -6,20 +6,20 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  name: ingesters.monitoring.paodin.io
+  name: stores.monitoring.whizard.io
 spec:
-  group: monitoring.paodin.io
+  group: monitoring.whizard.io
   names:
-    kind: Ingester
-    listKind: IngesterList
-    plural: ingesters
-    singular: ingester
+    kind: Store
+    listKind: StoreList
+    plural: stores
+    singular: store
   scope: Namespaced
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Ingester is the Schema for the Ingester API
+        description: Store is the Schema for the Store API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -34,7 +34,6 @@ spec:
           metadata:
             type: object
           spec:
-            description: IngesterSpec defines the desired state of a Ingester
             properties:
               affinity:
                 description: If specified, the pod's scheduling constraints.
@@ -1174,12 +1173,26 @@ spec:
                   strategy parameters.
                 type: object
               image:
-                description: Image is the thanos image with tag/version
+                description: Image is the image with tag/version
                 type: string
-              localTsdbRetention:
-                description: LocalTsdbRetention configs how long to retain raw samples
-                  on local storage.
+              imagePullPolicy:
+                description: Image pull policy. One of Always, Never, IfNotPresent.
+                  Defaults to Always if :latest tag is specified, or IfNotPresent
+                  otherwise. Cannot be updated.
                 type: string
+              indexCacheConfig:
+                description: IndexCacheConfig contains index cache configuration.
+                properties:
+                  inMemory:
+                    properties:
+                      maxSize:
+                        description: MaxSize represents overall maximum number of
+                          bytes cache can contain.
+                        type: string
+                    required:
+                    - maxSize
+                    type: object
+                type: object
               logFormat:
                 description: 'Log format to use. Possible options: logfmt or json'
                 type: string
@@ -1187,13 +1200,19 @@ spec:
                 description: 'Log filtering level. Possible options: error, warn,
                   info, debug'
                 type: string
+              maxTime:
+                description: MaxTime specifies end of time range limit to serve
+                type: string
+              minTime:
+                description: MinTime specifies start of time range limit to serve
+                type: string
               nodeSelector:
                 additionalProperties:
                   type: string
                 description: Define which Nodes the Pods are scheduled on.
                 type: object
               replicas:
-                description: Number of replicas for a component.
+                description: Number of replicas for a component
                 format: int32
                 type: integer
               resources:
@@ -1222,21 +1241,642 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
+              scaler:
+                properties:
+                  behavior:
+                    description: behavior configures the scaling behavior of the target
+                      in both Up and Down directions (scaleUp and scaleDown fields
+                      respectively). If not set, the default HPAScalingRules for scale
+                      up and scale down are used.
+                    properties:
+                      scaleDown:
+                        description: scaleDown is scaling policy for scaling Down.
+                          If not set, the default value is to allow to scale down
+                          to minReplicas pods, with a 300 second stabilization window
+                          (i.e., the highest recommendation for the last 300sec is
+                          used).
+                        properties:
+                          policies:
+                            description: policies is a list of potential scaling polices
+                              which can be used during scaling. At least one policy
+                              must be specified, otherwise the HPAScalingRules will
+                              be discarded as invalid
+                            items:
+                              description: HPAScalingPolicy is a single policy which
+                                must hold true for a specified past interval.
+                              properties:
+                                periodSeconds:
+                                  description: PeriodSeconds specifies the window
+                                    of time for which the policy should hold true.
+                                    PeriodSeconds must be greater than zero and less
+                                    than or equal to 1800 (30 min).
+                                  format: int32
+                                  type: integer
+                                type:
+                                  description: Type is used to specify the scaling
+                                    policy.
+                                  type: string
+                                value:
+                                  description: Value contains the amount of change
+                                    which is permitted by the policy. It must be greater
+                                    than zero
+                                  format: int32
+                                  type: integer
+                              required:
+                              - periodSeconds
+                              - type
+                              - value
+                              type: object
+                            type: array
+                          selectPolicy:
+                            description: selectPolicy is used to specify which policy
+                              should be used. If not set, the default value MaxPolicySelect
+                              is used.
+                            type: string
+                          stabilizationWindowSeconds:
+                            description: 'StabilizationWindowSeconds is the number
+                              of seconds for which past recommendations should be
+                              considered while scaling up or scaling down. StabilizationWindowSeconds
+                              must be greater than or equal to zero and less than
+                              or equal to 3600 (one hour). If not set, use the default
+                              values: - For scale up: 0 (i.e. no stabilization is
+                              done). - For scale down: 300 (i.e. the stabilization
+                              window is 300 seconds long).'
+                            format: int32
+                            type: integer
+                        type: object
+                      scaleUp:
+                        description: 'scaleUp is scaling policy for scaling Up. If
+                          not set, the default value is the higher of:   * increase
+                          no more than 4 pods per 60 seconds   * double the number
+                          of pods per 60 seconds No stabilization is used.'
+                        properties:
+                          policies:
+                            description: policies is a list of potential scaling polices
+                              which can be used during scaling. At least one policy
+                              must be specified, otherwise the HPAScalingRules will
+                              be discarded as invalid
+                            items:
+                              description: HPAScalingPolicy is a single policy which
+                                must hold true for a specified past interval.
+                              properties:
+                                periodSeconds:
+                                  description: PeriodSeconds specifies the window
+                                    of time for which the policy should hold true.
+                                    PeriodSeconds must be greater than zero and less
+                                    than or equal to 1800 (30 min).
+                                  format: int32
+                                  type: integer
+                                type:
+                                  description: Type is used to specify the scaling
+                                    policy.
+                                  type: string
+                                value:
+                                  description: Value contains the amount of change
+                                    which is permitted by the policy. It must be greater
+                                    than zero
+                                  format: int32
+                                  type: integer
+                              required:
+                              - periodSeconds
+                              - type
+                              - value
+                              type: object
+                            type: array
+                          selectPolicy:
+                            description: selectPolicy is used to specify which policy
+                              should be used. If not set, the default value MaxPolicySelect
+                              is used.
+                            type: string
+                          stabilizationWindowSeconds:
+                            description: 'StabilizationWindowSeconds is the number
+                              of seconds for which past recommendations should be
+                              considered while scaling up or scaling down. StabilizationWindowSeconds
+                              must be greater than or equal to zero and less than
+                              or equal to 3600 (one hour). If not set, use the default
+                              values: - For scale up: 0 (i.e. no stabilization is
+                              done). - For scale down: 300 (i.e. the stabilization
+                              window is 300 seconds long).'
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                  maxReplicas:
+                    description: maxReplicas is the upper limit for the number of
+                      replicas to which the autoscaler can scale up. It cannot be
+                      less that minReplicas.
+                    format: int32
+                    type: integer
+                  metrics:
+                    description: metrics contains the specifications for which to
+                      use to calculate the desired replica count (the maximum replica
+                      count across all metrics will be used).  The desired replica
+                      count is calculated multiplying the ratio between the target
+                      value and the current value by the current number of pods.  Ergo,
+                      metrics used must decrease as the pod count is increased, and
+                      vice-versa.  See the individual metric source types for more
+                      information about how each type of metric must respond. If not
+                      set, the default metric will be set to 80% average CPU utilization.
+                    items:
+                      description: MetricSpec specifies how to scale based on a single
+                        metric (only `type` and one other matching field should be
+                        set at once).
+                      properties:
+                        containerResource:
+                          description: container resource refers to a resource metric
+                            (such as those specified in requests and limits) known
+                            to Kubernetes describing a single container in each pod
+                            of the current scale target (e.g. CPU or memory). Such
+                            metrics are built in to Kubernetes, and have special scaling
+                            options on top of those available to normal per-pod metrics
+                            using the "pods" source. This is an alpha feature and
+                            can be enabled by the HPAContainerMetrics feature flag.
+                          properties:
+                            container:
+                              description: container is the name of the container
+                                in the pods of the scaling target
+                              type: string
+                            name:
+                              description: name is the name of the resource in question.
+                              type: string
+                            target:
+                              description: target specifies the target value for the
+                                given metric
+                              properties:
+                                averageUtilization:
+                                  description: averageUtilization is the target value
+                                    of the average of the resource metric across all
+                                    relevant pods, represented as a percentage of
+                                    the requested value of the resource for the pods.
+                                    Currently only valid for Resource metric source
+                                    type
+                                  format: int32
+                                  type: integer
+                                averageValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: averageValue is the target value of
+                                    the average of the metric across all relevant
+                                    pods (as a quantity)
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: type represents whether the metric
+                                    type is Utilization, Value, or AverageValue
+                                  type: string
+                                value:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: value is the target value of the metric
+                                    (as a quantity).
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - type
+                              type: object
+                          required:
+                          - container
+                          - name
+                          - target
+                          type: object
+                        external:
+                          description: external refers to a global metric that is
+                            not associated with any Kubernetes object. It allows autoscaling
+                            based on information coming from components running outside
+                            of cluster (for example length of queue in cloud messaging
+                            service, or QPS from loadbalancer running outside of cluster).
+                          properties:
+                            metric:
+                              description: metric identifies the target metric by
+                                name and selector
+                              properties:
+                                name:
+                                  description: name is the name of the given metric
+                                  type: string
+                                selector:
+                                  description: selector is the string-encoded form
+                                    of a standard kubernetes label selector for the
+                                    given metric When set, it is passed as an additional
+                                    parameter to the metrics server for more specific
+                                    metrics scoping. When unset, just the metricName
+                                    will be used to gather metrics.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            target:
+                              description: target specifies the target value for the
+                                given metric
+                              properties:
+                                averageUtilization:
+                                  description: averageUtilization is the target value
+                                    of the average of the resource metric across all
+                                    relevant pods, represented as a percentage of
+                                    the requested value of the resource for the pods.
+                                    Currently only valid for Resource metric source
+                                    type
+                                  format: int32
+                                  type: integer
+                                averageValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: averageValue is the target value of
+                                    the average of the metric across all relevant
+                                    pods (as a quantity)
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: type represents whether the metric
+                                    type is Utilization, Value, or AverageValue
+                                  type: string
+                                value:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: value is the target value of the metric
+                                    (as a quantity).
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - type
+                              type: object
+                          required:
+                          - metric
+                          - target
+                          type: object
+                        object:
+                          description: object refers to a metric describing a single
+                            kubernetes object (for example, hits-per-second on an
+                            Ingress object).
+                          properties:
+                            describedObject:
+                              description: CrossVersionObjectReference contains enough
+                                information to let you identify the referred resource.
+                              properties:
+                                apiVersion:
+                                  description: API version of the referent
+                                  type: string
+                                kind:
+                                  description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                                  type: string
+                                name:
+                                  description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            metric:
+                              description: metric identifies the target metric by
+                                name and selector
+                              properties:
+                                name:
+                                  description: name is the name of the given metric
+                                  type: string
+                                selector:
+                                  description: selector is the string-encoded form
+                                    of a standard kubernetes label selector for the
+                                    given metric When set, it is passed as an additional
+                                    parameter to the metrics server for more specific
+                                    metrics scoping. When unset, just the metricName
+                                    will be used to gather metrics.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            target:
+                              description: target specifies the target value for the
+                                given metric
+                              properties:
+                                averageUtilization:
+                                  description: averageUtilization is the target value
+                                    of the average of the resource metric across all
+                                    relevant pods, represented as a percentage of
+                                    the requested value of the resource for the pods.
+                                    Currently only valid for Resource metric source
+                                    type
+                                  format: int32
+                                  type: integer
+                                averageValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: averageValue is the target value of
+                                    the average of the metric across all relevant
+                                    pods (as a quantity)
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: type represents whether the metric
+                                    type is Utilization, Value, or AverageValue
+                                  type: string
+                                value:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: value is the target value of the metric
+                                    (as a quantity).
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - type
+                              type: object
+                          required:
+                          - describedObject
+                          - metric
+                          - target
+                          type: object
+                        pods:
+                          description: pods refers to a metric describing each pod
+                            in the current scale target (for example, transactions-processed-per-second).  The
+                            values will be averaged together before being compared
+                            to the target value.
+                          properties:
+                            metric:
+                              description: metric identifies the target metric by
+                                name and selector
+                              properties:
+                                name:
+                                  description: name is the name of the given metric
+                                  type: string
+                                selector:
+                                  description: selector is the string-encoded form
+                                    of a standard kubernetes label selector for the
+                                    given metric When set, it is passed as an additional
+                                    parameter to the metrics server for more specific
+                                    metrics scoping. When unset, just the metricName
+                                    will be used to gather metrics.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            target:
+                              description: target specifies the target value for the
+                                given metric
+                              properties:
+                                averageUtilization:
+                                  description: averageUtilization is the target value
+                                    of the average of the resource metric across all
+                                    relevant pods, represented as a percentage of
+                                    the requested value of the resource for the pods.
+                                    Currently only valid for Resource metric source
+                                    type
+                                  format: int32
+                                  type: integer
+                                averageValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: averageValue is the target value of
+                                    the average of the metric across all relevant
+                                    pods (as a quantity)
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: type represents whether the metric
+                                    type is Utilization, Value, or AverageValue
+                                  type: string
+                                value:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: value is the target value of the metric
+                                    (as a quantity).
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - type
+                              type: object
+                          required:
+                          - metric
+                          - target
+                          type: object
+                        resource:
+                          description: resource refers to a resource metric (such
+                            as those specified in requests and limits) known to Kubernetes
+                            describing each pod in the current scale target (e.g.
+                            CPU or memory). Such metrics are built in to Kubernetes,
+                            and have special scaling options on top of those available
+                            to normal per-pod metrics using the "pods" source.
+                          properties:
+                            name:
+                              description: name is the name of the resource in question.
+                              type: string
+                            target:
+                              description: target specifies the target value for the
+                                given metric
+                              properties:
+                                averageUtilization:
+                                  description: averageUtilization is the target value
+                                    of the average of the resource metric across all
+                                    relevant pods, represented as a percentage of
+                                    the requested value of the resource for the pods.
+                                    Currently only valid for Resource metric source
+                                    type
+                                  format: int32
+                                  type: integer
+                                averageValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: averageValue is the target value of
+                                    the average of the metric across all relevant
+                                    pods (as a quantity)
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: type represents whether the metric
+                                    type is Utilization, Value, or AverageValue
+                                  type: string
+                                value:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: value is the target value of the metric
+                                    (as a quantity).
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - type
+                              type: object
+                          required:
+                          - name
+                          - target
+                          type: object
+                        type:
+                          description: 'type is the type of metric source.  It should
+                            be one of "ContainerResource", "External", "Object", "Pods"
+                            or "Resource", each mapping to a matching field in the
+                            object. Note: "ContainerResource" type is available on
+                            when the feature-gate HPAContainerMetrics is enabled'
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    type: array
+                  minReplicas:
+                    description: minReplicas is the lower limit for the number of
+                      replicas to which the autoscaler can scale down.  It defaults
+                      to 1 pod.  minReplicas is allowed to be 0 if the alpha feature
+                      gate HPAScaleToZero is enabled and at least one Object or External
+                      metric is configured.  Scaling is active as long as at least
+                      one metric value is available.
+                    format: int32
+                    type: integer
+                required:
+                - maxReplicas
+                type: object
               storage:
-                description: If specified, the object key of Storage for long term
-                  storage.
                 properties:
                   name:
                     type: string
                   namespace:
                     type: string
                 type: object
-              tenants:
-                description: Tenants if not empty indicates current config is for
-                  hard tenants; otherwise, it is for soft tenants.
-                items:
-                  type: string
-                type: array
               tolerations:
                 description: If specified, the pod's tolerations.
                 items:
@@ -1279,7 +1919,7 @@ spec:
                 type: array
             type: object
           status:
-            description: IngesterStatus defines the observed state of Ingester
+            description: StoreStatus defines the observed state of Store
             type: object
         type: object
     served: true

--- a/config/crd/bases/monitoring.whizard.io_tenants.yaml
+++ b/config/crd/bases/monitoring.whizard.io_tenants.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  name: tenants.monitoring.paodin.io
+  name: tenants.monitoring.whizard.io
 spec:
-  group: monitoring.paodin.io
+  group: monitoring.whizard.io
   names:
     kind: Tenant
     listKind: TenantList

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,15 +2,15 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/monitoring.paodin.io_services.yaml
-- bases/monitoring.paodin.io_stores.yaml
-- bases/monitoring.paodin.io_compactors.yaml
-- bases/monitoring.paodin.io_ingesters.yaml
-- bases/monitoring.paodin.io_rulers.yaml
-- bases/monitoring.paodin.io_rules.yaml
-- bases/monitoring.paodin.io_rulegroups.yaml
-- bases/monitoring.paodin.io_storages.yaml
-- bases/monitoring.paodin.io_tenants.yaml
+- bases/monitoring.whizard.io_services.yaml
+- bases/monitoring.whizard.io_stores.yaml
+- bases/monitoring.whizard.io_compactors.yaml
+- bases/monitoring.whizard.io_ingesters.yaml
+- bases/monitoring.whizard.io_rulers.yaml
+- bases/monitoring.whizard.io_rules.yaml
+- bases/monitoring.whizard.io_rulegroups.yaml
+- bases/monitoring.whizard.io_storages.yaml
+- bases/monitoring.whizard.io_tenants.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/config/crd/patches/cainjection_in_services.yaml
+++ b/config/crd/patches/cainjection_in_services.yaml
@@ -4,4 +4,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: services.monitoring.paodin.io
+  name: services.monitoring.whizard.io

--- a/config/crd/patches/webhook_in_services.yaml
+++ b/config/crd/patches/webhook_in_services.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: services.monitoring.paodin.io
+  name: services.monitoring.whizard.io
 spec:
   conversion:
     strategy: Webhook

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -6,7 +6,7 @@ namespace: kubesphere-monitoring-system
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: paodin-
+namePrefix: whizard-
 
 # Labels to add to all resources and selectors.
 #commonLabels:

--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -8,4 +8,4 @@ webhook:
   port: 9443
 leaderElection:
   leaderElect: true
-  resourceName: paodin-controller-manager-leader-election
+  resourceName: whizard-controller-manager-leader-election

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,7 +12,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: kubesphere/paodin-controller-manager
+  newName: kubesphere/whizard-controller-manager
   newTag: latest
 
 vars:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -115,7 +115,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - alertingrules
   verbs:
@@ -123,7 +123,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - compactors
   verbs:
@@ -135,13 +135,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - compactors/finalizers
   verbs:
   - update
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - compactors/status
   verbs:
@@ -149,7 +149,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - ingesters
   verbs:
@@ -161,13 +161,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - ingesters/finalizers
   verbs:
   - update
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - ingesters/status
   verbs:
@@ -175,7 +175,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - rulegroups
   verbs:
@@ -183,7 +183,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - rulers
   verbs:
@@ -195,13 +195,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - rulers/finalizers
   verbs:
   - update
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - rulers/status
   verbs:
@@ -209,7 +209,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - rules
   verbs:
@@ -217,7 +217,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - service
   verbs:
@@ -225,7 +225,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - services
   verbs:
@@ -237,13 +237,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - services/finalizers
   verbs:
   - update
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - services/status
   verbs:
@@ -251,7 +251,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - storage
   verbs:
@@ -259,7 +259,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - storages
   verbs:
@@ -271,7 +271,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - stores
   verbs:
@@ -283,13 +283,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - stores/finalizers
   verbs:
   - update
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - stores/status
   verbs:
@@ -297,7 +297,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - tenants
   verbs:
@@ -310,13 +310,13 @@ rules:
   - verbs=get
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - tenants/finalizers
   verbs:
   - update
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - tenants/status
   verbs:

--- a/config/rbac/service_editor_role.yaml
+++ b/config/rbac/service_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: service-editor-role
 rules:
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - service
   verbs:
@@ -17,7 +17,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - service/status
   verbs:

--- a/config/rbac/service_viewer_role.yaml
+++ b/config/rbac/service_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: service-viewer-role
 rules:
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - service
   verbs:
@@ -13,7 +13,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - monitoring.paodin.io
+  - monitoring.whizard.io
   resources:
   - service/status
   verbs:

--- a/config/samples/monitoring_v1alpha1_service.yaml
+++ b/config/samples/monitoring_v1alpha1_service.yaml
@@ -1,4 +1,4 @@
-apiVersion: monitoring.paodin.io/v1alpha1
+apiVersion: monitoring.whizard.io/v1alpha1
 kind: Service
 metadata:
   name: central
@@ -9,5 +9,5 @@ spec:
   query:
     replicaLabelNames:
       - prometheus_replica
-      - thanos_receive_replica
-      - thanos_ruler_replica
+      - receive_replica
+      - ruler_replica

--- a/docs/monitoring/api.md
+++ b/docs/monitoring/api.md
@@ -1,86 +1,171 @@
-
-
 # API Docs
 
-This Document documents the types introduced by the paodin to be consumed by users.
+This Document documents the types introduced by the whizard to be consumed by users.
 
 > Note this document is generated from code comments. When contributing a change to this document please do so by changing the code comments.
 
 ## Table of Contents
-* [AlertingRule](#alertingrule)
-* [AlertingRuleList](#alertingrulelist)
-* [AlertingRuleSpec](#alertingrulespec)
+* [Tenant](#tenant)
+* [TenantList](#tenantlist)
+* [TenantSpec](#tenantspec)
+* [TenantStatus](#tenantstatus)
+* [AutoScaler](#autoscaler)
+* [Compactor](#compactor)
+* [CompactorList](#compactorlist)
+* [CompactorSpec](#compactorspec)
 * [EnvoySpec](#envoyspec)
 * [Gateway](#gateway)
+* [InMemoryIndexCacheConfig](#inmemoryindexcacheconfig)
+* [InMemoryResponseCacheConfig](#inmemoryresponsecacheconfig)
+* [IndexCacheConfig](#indexcacheconfig)
+* [Ingester](#ingester)
+* [IngesterList](#ingesterlist)
+* [IngesterSpec](#ingesterspec)
 * [KubernetesVolume](#kubernetesvolume)
 * [ObjectReference](#objectreference)
 * [Query](#query)
+* [QueryFrontend](#queryfrontend)
 * [QueryStores](#querystores)
+* [ResponseCacheProviderConfig](#responsecacheproviderconfig)
 * [Retention](#retention)
+* [Router](#router)
+* [Rule](#rule)
 * [RuleGroup](#rulegroup)
 * [RuleGroupList](#rulegrouplist)
 * [RuleGroupSpec](#rulegroupspec)
+* [RuleList](#rulelist)
+* [RuleSpec](#rulespec)
+* [Ruler](#ruler)
+* [RulerList](#rulerlist)
+* [RulerSpec](#rulerspec)
 * [Service](#service)
 * [ServiceList](#servicelist)
 * [ServiceSpec](#servicespec)
 * [Store](#store)
 * [StoreList](#storelist)
 * [StoreSpec](#storespec)
-* [Thanos](#thanos)
-* [ThanosCompact](#thanoscompact)
-* [ThanosReceiveIngestor](#thanosreceiveingestor)
-* [ThanosReceiveIngestorList](#thanosreceiveingestorlist)
-* [ThanosReceiveIngestorSpec](#thanosreceiveingestorspec)
-* [ThanosReceiveRouter](#thanosreceiverouter)
-* [ThanosRuler](#thanosruler)
-* [ThanosRulerList](#thanosrulerlist)
-* [ThanosRulerSpec](#thanosrulerspec)
-* [ThanosStore](#thanosstore)
-* [ThanosStoreGateway](#thanosstoregateway)
+* [S3](#s3)
+* [S3HTTPConfig](#s3httpconfig)
+* [S3SSEConfig](#s3sseconfig)
+* [S3TraceConfig](#s3traceconfig)
+* [Storage](#storage)
+* [StorageList](#storagelist)
+* [StorageSpec](#storagespec)
+* [TLSConfig](#tlsconfig)
 
-## AlertingRule
+## Tenant
 
-AlertingRule is the Schema for the AlertingRule API
+Tenant is the Schema for the monitoring Tenant API
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta) | false |
-| spec |  | [AlertingRuleSpec](#alertingrulespec) | false |
-| status |  | [AlertingRuleStatus](#alertingrulestatus) | false |
+| spec |  | [TenantSpec](#tenantspec) | false |
+| status |  | [TenantStatus](#tenantstatus) | false |
 
 [Back to TOC](#table-of-contents)
 
-## AlertingRuleList
+## TenantList
 
-AlertingRuleList contains a list of AlertingRule
+
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | metadata |  | [metav1.ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#listmeta-v1-meta) | false |
-| items |  | [][AlertingRule](#alertingrule) | true |
+| items |  | [][Tenant](#tenant) | true |
 
 [Back to TOC](#table-of-contents)
 
-## AlertingRuleSpec
+## TenantSpec
 
-AlertingRuleSpec defines the desired state of a AlertingRule
+
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| expr |  | intstr.IntOrString | true |
-| for |  | string | false |
-| labels |  | map[string]string | false |
-| annotations |  | map[string]string | false |
+| tenant |  | string | false |
+| storage |  | *[ObjectReference](#objectreference) | false |
+
+[Back to TOC](#table-of-contents)
+
+## TenantStatus
+
+
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| ruler |  | *[ObjectReference](#objectreference) | false |
+| compactor |  | *[ObjectReference](#objectreference) | false |
+| ingester |  | *[ObjectReference](#objectreference) | false |
+
+[Back to TOC](#table-of-contents)
+
+## AutoScaler
+
+
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| minReplicas | minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  Scaling is active as long as at least one metric value is available. | *int32 | false |
+| maxReplicas | maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas. | int32 | true |
+| metrics | metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used).  The desired replica count is calculated multiplying the ratio between the target value and the current value by the current number of pods.  Ergo, metrics used must decrease as the pod count is increased, and vice-versa.  See the individual metric source types for more information about how each type of metric must respond. If not set, the default metric will be set to 80% average CPU utilization. | []v2beta2.MetricSpec | false |
+| behavior | behavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively). If not set, the default HPAScalingRules for scale up and scale down are used. | *v2beta2.HorizontalPodAutoscalerBehavior | false |
+
+[Back to TOC](#table-of-contents)
+
+## Compactor
+
+Compactor is the Schema for the Compactor API
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta) | false |
+| spec |  | [CompactorSpec](#compactorspec) | false |
+| status |  | [CompactorStatus](#compactorstatus) | false |
+
+[Back to TOC](#table-of-contents)
+
+## CompactorList
+
+CompactorList contains a list of Compactor
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| metadata |  | [metav1.ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#listmeta-v1-meta) | false |
+| items |  | [][Compactor](#compactor) | true |
+
+[Back to TOC](#table-of-contents)
+
+## CompactorSpec
+
+
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| affinity | If specified, the pod's scheduling constraints. | *corev1.Affinity | false |
+| nodeSelector | Define which Nodes the Pods are scheduled on. | map[string]string | false |
+| tolerations | If specified, the pod's tolerations. | []corev1.Toleration | false |
+| resources | Define resources requests and limits for main container. | [corev1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core) | false |
+| replicas | Number of replicas for a component | *int32 | false |
+| image | Image is the image with tag/version | string | false |
+| imagePullPolicy | Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. | [corev1.PullPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#container-v1-core) | false |
+| logLevel | Log filtering level. Possible options: error, warn, info, debug | string | false |
+| logFormat | Log format to use. Possible options: logfmt or json | string | false |
+| downsamplingDisable | DownsamplingDisable specifies whether to disable downsampling | *bool | false |
+| retention | Retention configs how long to retain samples | *[Retention](#retention) | false |
+| storage |  | *[ObjectReference](#objectreference) | false |
+| flags | Flags is a list of key/value that could be used to set strategy parameters. | map[string]string | false |
+| dataVolume | DataVolume specifies how volume shall be used | *[KubernetesVolume](#kubernetesvolume) | false |
+| tenants | Tenants if not empty indicates current config is for hard tenants; otherwise, it is for soft tenants. | []string | false |
 
 [Back to TOC](#table-of-contents)
 
 ## EnvoySpec
 
-EnvoySpec defines the desired state of envoy proxy sidecar which delegates requests to the secure thanos stores
+EnvoySpec defines the desired state of envoy proxy sidecar which delegates requests to the secure stores
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| image | Image is the thanos image with tag/version | string | false |
+| image | Image is the envoy image with tag/version | string | false |
 | resources | Define resources requests and limits for envoy container. | [corev1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core) | false |
 
 [Back to TOC](#table-of-contents)
@@ -95,7 +180,7 @@ EnvoySpec defines the desired state of envoy proxy sidecar which delegates reque
 | nodeSelector | Define which Nodes the Pods are scheduled on. | map[string]string | false |
 | tolerations | If specified, the pod's tolerations. | []corev1.Toleration | false |
 | resources | Define resources requests and limits for main container. | [corev1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core) | false |
-| replicas | Number of replicas for a thanos component | *int32 | false |
+| replicas | Number of replicas for a component | *int32 | false |
 | image | Image is the gateway image with tag/version. | string | false |
 | logLevel | Log filtering level. Possible options: error, warn, info, debug. | string | false |
 | logFormat | Log format to use. Possible options: logfmt or json. | string | false |
@@ -104,9 +189,86 @@ EnvoySpec defines the desired state of envoy proxy sidecar which delegates reque
 
 [Back to TOC](#table-of-contents)
 
+## InMemoryIndexCacheConfig
+
+
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| maxSize | MaxSize represents overall maximum number of bytes cache can contain. | string | true |
+
+[Back to TOC](#table-of-contents)
+
+## InMemoryResponseCacheConfig
+
+InMemoryResponseCacheConfig holds the configs for the in-memory cache provider.
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| maxSize | MaxSize represents overall maximum number of bytes cache can contain. | string | true |
+| maxSizeItems | MaxSizeItems represents the maximum number of entries in the cache. | int | true |
+| validity | Validity represents the expiry duration for the cache. | time.Duration | true |
+
+[Back to TOC](#table-of-contents)
+
+## IndexCacheConfig
+
+IndexCacheConfig specifies the index cache config.
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| inMemory |  | *[InMemoryIndexCacheConfig](#inmemoryindexcacheconfig) | false |
+
+[Back to TOC](#table-of-contents)
+
+## Ingester
+
+Ingester is the Schema for the Ingester API
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta) | false |
+| spec |  | [IngesterSpec](#ingesterspec) | false |
+| status |  | [IngesterStatus](#ingesterstatus) | false |
+
+[Back to TOC](#table-of-contents)
+
+## IngesterList
+
+IngesterList contains a list of Ingester
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| metadata |  | [metav1.ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#listmeta-v1-meta) | false |
+| items |  | [][Ingester](#ingester) | true |
+
+[Back to TOC](#table-of-contents)
+
+## IngesterSpec
+
+IngesterSpec defines the desired state of a Ingester
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| tenants | Tenants if not empty indicates current config is for hard tenants; otherwise, it is for soft tenants. | []string | false |
+| affinity | If specified, the pod's scheduling constraints. | *corev1.Affinity | false |
+| nodeSelector | Define which Nodes the Pods are scheduled on. | map[string]string | false |
+| tolerations | If specified, the pod's tolerations. | []corev1.Toleration | false |
+| resources | Define resources requests and limits for main container. | [corev1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core) | false |
+| replicas | Number of replicas for a component. | *int32 | false |
+| image | Image is the image with tag/version | string | false |
+| logLevel | Log filtering level. Possible options: error, warn, info, debug | string | false |
+| logFormat | Log format to use. Possible options: logfmt or json | string | false |
+| localTsdbRetention | LocalTsdbRetention configs how long to retain raw samples on local storage. | string | false |
+| flags | Flags is a list of key/value that could be used to set strategy parameters. | map[string]string | false |
+| storage | If specified, the object key of Storage for long term storage. | *[ObjectReference](#objectreference) | false |
+| dataVolume | DataVolume specifies how volume shall be used | *[KubernetesVolume](#kubernetesvolume) | false |
+
+[Back to TOC](#table-of-contents)
+
 ## KubernetesVolume
 
-KubernetesVolume defines the configured volume for a thanos instance.
+KubernetesVolume defines the configured volume for a instance.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
@@ -136,14 +298,34 @@ KubernetesVolume defines the configured volume for a thanos instance.
 | nodeSelector | Define which Nodes the Pods are scheduled on. | map[string]string | false |
 | tolerations | If specified, the pod's tolerations. | []corev1.Toleration | false |
 | resources | Define resources requests and limits for main container. | [corev1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core) | false |
-| replicas | Number of replicas for a thanos component | *int32 | false |
-| image | Image is the thanos image with tag/version | string | false |
+| replicas | Number of replicas for a component | *int32 | false |
+| image | Image is the image with tag/version | string | false |
 | logLevel | Log filtering level. Possible options: error, warn, info, debug | string | false |
 | logFormat | Log format to use. Possible options: logfmt or json | string | false |
-| stores | Additional StoreApi servers from which Thanos Query component queries from | [][QueryStores](#querystores) | false |
+| stores | Additional StoreApi servers from which Query component queries from | [][QueryStores](#querystores) | false |
 | selectorLabels | Selector labels that will be exposed in info endpoint. | map[string]string | false |
 | replicaLabelNames | Labels to treat as a replica indicator along which data is deduplicated. | []string | false |
+| flags | Flags is a list of key/value that could be used to set strategy parameters. | map[string]string | false |
 | envoy | Envoy is used to config sidecar which proxies requests requiring auth to the secure stores | [EnvoySpec](#envoyspec) | false |
+
+[Back to TOC](#table-of-contents)
+
+## QueryFrontend
+
+
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| affinity | If specified, the pod's scheduling constraints. | *corev1.Affinity | false |
+| nodeSelector | Define which Nodes the Pods are scheduled on. | map[string]string | false |
+| tolerations | If specified, the pod's tolerations. | []corev1.Toleration | false |
+| resources | Define resources requests and limits for main container. | [corev1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core) | false |
+| replicas | Number of replicas for a component | *int32 | false |
+| image | Image is the image with tag/version | string | false |
+| logLevel | Log filtering level. Possible options: error, warn, info, debug | string | false |
+| logFormat | Log format to use. Possible options: logfmt or json | string | false |
+| flags | Flags is a list of key/value that could be used to set strategy parameters. | map[string]string | false |
+| cacheConfig | CacheProviderConfig ... | *[ResponseCacheProviderConfig](#responsecacheproviderconfig) | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -153,8 +335,19 @@ KubernetesVolume defines the configured volume for a thanos instance.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| addresses | Address is the addresses of StoreApi server, which may be prefixed with 'dns+' or 'dnssrv+' to detect StoreAPI servers through respective DNS lookups. For more info, see https://thanos.io/tip/thanos/service-discovery.md/#dns-service-discovery | []string | false |
+| addresses | Address is the addresses of StoreApi server, which may be prefixed with 'dns+' or 'dnssrv+' to detect StoreAPI servers through respective DNS lookups. | []string | false |
 | caSecret | Secret containing the CA cert to use for StoreApi connections | *corev1.SecretKeySelector | false |
+
+[Back to TOC](#table-of-contents)
+
+## ResponseCacheProviderConfig
+
+ResponseCacheProviderConfig is the initial ResponseCacheProviderConfig struct holder before parsing it into a specific cache provider. Based on the config type the config is then parsed into a specific cache provider.
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| type |  | CacheProvider | true |
+| inMemory |  | *[InMemoryResponseCacheConfig](#inmemoryresponsecacheconfig) | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -164,9 +357,40 @@ Retention defines the config for retaining samples
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| retentionRaw | RetentionRaw specifies how long to retain raw samples in bucket | string | false |
-| retention5m | Retention5m specifies how long to retain samples of 5m resolution in bucket | string | false |
-| retention1h | Retention1h specifies how long to retain samples of 1h resolution in bucket | string | false |
+| retentionRaw | RetentionRaw specifies how long to retain raw samples in bucket | Duration | false |
+| retention5m | Retention5m specifies how long to retain samples of 5m resolution in bucket | Duration | false |
+| retention1h | Retention1h specifies how long to retain samples of 1h resolution in bucket | Duration | false |
+
+[Back to TOC](#table-of-contents)
+
+## Router
+
+
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| affinity | If specified, the pod's scheduling constraints. | *corev1.Affinity | false |
+| nodeSelector | Define which Nodes the Pods are scheduled on. | map[string]string | false |
+| tolerations | If specified, the pod's tolerations. | []corev1.Toleration | false |
+| resources | Define resources requests and limits for main container. | [corev1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core) | false |
+| replicas | Number of replicas for a component. | *int32 | false |
+| image | Image is the image with tag/version | string | false |
+| logLevel | Log filtering level. Possible options: error, warn, info, debug | string | false |
+| logFormat | Log format to use. Possible options: logfmt or json | string | false |
+| replicationFactor | How many times to replicate incoming write requests | *uint64 | false |
+| flags | Flags is a list of key/value that could be used to set strategy parameters. | map[string]string | false |
+
+[Back to TOC](#table-of-contents)
+
+## Rule
+
+Rule is the Schema for the Rule API
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta) | false |
+| spec |  | [RuleSpec](#rulespec) | false |
+| status |  | [RuleStatus](#rulestatus) | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -204,6 +428,83 @@ RuleGroupSpec defines the desired state of a RuleGroup
 
 [Back to TOC](#table-of-contents)
 
+## RuleList
+
+RuleList contains a list of Rule
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| metadata |  | [metav1.ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#listmeta-v1-meta) | false |
+| items |  | [][Rule](#rule) | true |
+
+[Back to TOC](#table-of-contents)
+
+## RuleSpec
+
+RuleSpec defines the desired state of a Rule
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| alert |  | string | false |
+| record |  | string | false |
+| expr |  | intstr.IntOrString | true |
+| for |  | Duration | false |
+| labels |  | map[string]string | false |
+| annotations |  | map[string]string | false |
+
+[Back to TOC](#table-of-contents)
+
+## Ruler
+
+Ruler is the Schema for the Ruler API
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta) | false |
+| spec |  | [RulerSpec](#rulerspec) | false |
+| status |  | [RulerStatus](#rulerstatus) | false |
+
+[Back to TOC](#table-of-contents)
+
+## RulerList
+
+RulerList contains a list of Ruler
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| metadata |  | [metav1.ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#listmeta-v1-meta) | false |
+| items |  | [][Ruler](#ruler) | true |
+
+[Back to TOC](#table-of-contents)
+
+## RulerSpec
+
+RulerSpec defines the desired state of a Ruler
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| affinity | If specified, the pod's scheduling constraints. | *corev1.Affinity | false |
+| nodeSelector | Define which Nodes the Pods are scheduled on. | map[string]string | false |
+| tolerations | If specified, the pod's tolerations. | []corev1.Toleration | false |
+| resources | Define resources requests and limits for main container. | [corev1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core) | false |
+| replicas | Number of replicas for a component. | *int32 | false |
+| image | Image is the image with tag/version | string | false |
+| logLevel | Log filtering level. Possible options: error, warn, info, debug | string | false |
+| logFormat | Log format to use. Possible options: logfmt or json | string | false |
+| ruleSelector | A label selector to select which Rules to mount for alerting and recording. | *[metav1.LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#labelselector-v1-meta) | false |
+| ruleNamespaceSelector | Namespaces to be selected for Rules discovery. If nil, only the same namespace as the Ruler object is in is used. | *[metav1.LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#labelselector-v1-meta) | false |
+| prometheusRuleSelector | A label selector to select which PrometheusRules to mount for alerting and recording. | *[metav1.LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#labelselector-v1-meta) | false |
+| prometheusRuleNamespaceSelector | Namespaces to be selected for PrometheusRules discovery. If unspecified, only the same namespace as the Ruler object is in is used. | *[metav1.LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#labelselector-v1-meta) | false |
+| tenant | Tenant if not empty indicates which tenant's data is evaluated for the selected rules; otherwise, it is for all tenants. | string | false |
+| labels | Labels configure the external label pairs to Ruler. A default replica label `ruler_replica` will be always added  as a label with the value of the pod's name and it will be dropped in the alerts. | map[string]string | false |
+| alertDropLabels | AlertDropLabels configure the label names which should be dropped in Ruler alerts. The replica label `ruler_replica` will always be dropped in alerts. | []string | false |
+| alertmanagersConfig | Define configuration for connecting to alertmanager. Maps to the `alertmanagers.config` arg. | *corev1.SecretKeySelector | false |
+| evaluationInterval | Interval between consecutive evaluations. Default: `30s` | Duration | false |
+| flags | Flags is a list of key/value that could be used to set strategy parameters. | map[string]string | false |
+| dataVolume | DataVolume specifies how volume shall be used | *[KubernetesVolume](#kubernetesvolume) | false |
+
+[Back to TOC](#table-of-contents)
+
 ## Service
 
 Service is the Schema for the monitoring service API
@@ -236,8 +537,11 @@ ServiceSpec defines the desired state of a Service
 | tenantHeader | HTTP header to determine tenant for remote write requests. | string | false |
 | defaultTenantId | Default tenant ID to use when none is provided via a header. | string | false |
 | tenantLabelName | Label name through which the tenant will be announced. | string | false |
-| gateway | Gateway to proxy and auth requests to Thanos Query and Thanos Receive Router defined in Thanos. | *[Gateway](#gateway) | false |
-| thanos | Thanos cluster contains explicit Thanos Query and Thanos Receive Router, and implicit Thanos Receive Ingestor and Thanos Store Gateway and Thanos Compact which are selected by label selector `monitoring.paodin.io/service=<service_namespace>.<service_name>`. | *[Thanos](#thanos) | false |
+| storage |  | *[ObjectReference](#objectreference) | false |
+| gateway | Gateway to proxy and auth requests to Query and Router. | *[Gateway](#gateway) | false |
+| query | Query component querys from the backends such as Ingester and Store by automated discovery. | *[Query](#query) | false |
+| router | Receive Router component routes to the backends such as Ingester by automated discovery. | *[Router](#router) | false |
+| queryFrontend | QueryFrontend component implements a service deployed in front of queriers to improve query parallelization and caching. | *[QueryFrontend](#queryfrontend) | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -266,28 +570,6 @@ StoreList contains a list of Store
 
 ## StoreSpec
 
-StoreSpec defines the desired state of a Store
-
-| Field | Description | Scheme | Required |
-| ----- | ----------- | ------ | -------- |
-| objectStorageConfig | ObjectStorageConfig allows specifying a key of a Secret containing object store configuration | *corev1.SecretKeySelector | false |
-| thanos | Thanos contains Thanos Store Gateway and Thanos Compact. | *[ThanosStore](#thanosstore) | false |
-
-[Back to TOC](#table-of-contents)
-
-## Thanos
-
-
-
-| Field | Description | Scheme | Required |
-| ----- | ----------- | ------ | -------- |
-| query | Thanos Query component querys from the backends such as Thanos Receive Ingestor and Thanos Store Gateway by automated discovery. | *[Query](#query) | false |
-| receiveRouter | Thanos Receive Router component routes to the backends such as Thanos Receive Ingestor by automated discovery. | *[ThanosReceiveRouter](#thanosreceiverouter) | false |
-
-[Back to TOC](#table-of-contents)
-
-## ThanosCompact
-
 
 
 | Field | Description | Scheme | Required |
@@ -296,152 +578,132 @@ StoreSpec defines the desired state of a Store
 | nodeSelector | Define which Nodes the Pods are scheduled on. | map[string]string | false |
 | tolerations | If specified, the pod's tolerations. | []corev1.Toleration | false |
 | resources | Define resources requests and limits for main container. | [corev1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core) | false |
-| replicas | Number of replicas for a thanos component | *int32 | false |
-| image | Image is the thanos image with tag/version | string | false |
+| replicas | Number of replicas for a component | *int32 | false |
+| image | Image is the image with tag/version | string | false |
+| imagePullPolicy | Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. | [corev1.PullPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#container-v1-core) | false |
 | logLevel | Log filtering level. Possible options: error, warn, info, debug | string | false |
 | logFormat | Log format to use. Possible options: logfmt or json | string | false |
-| downsamplingDisable | DownsamplingDisable specifies whether to disable downsampling | *bool | false |
-| retention | Retention configs how long to retain samples | *[Retention](#retention) | false |
-| dataVolume | DataVolume specifies how volume shall be used | *[KubernetesVolume](#kubernetesvolume) | false |
-
-[Back to TOC](#table-of-contents)
-
-## ThanosReceiveIngestor
-
-ThanosReceiveIngestor is the Schema for the ThanosReceiveIngestor API
-
-| Field | Description | Scheme | Required |
-| ----- | ----------- | ------ | -------- |
-| metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta) | false |
-| spec |  | [ThanosReceiveIngestorSpec](#thanosreceiveingestorspec) | false |
-| status |  | [ThanosReceiveIngestorStatus](#thanosreceiveingestorstatus) | false |
-
-[Back to TOC](#table-of-contents)
-
-## ThanosReceiveIngestorList
-
-ThanosReceiveIngestorList contains a list of Store
-
-| Field | Description | Scheme | Required |
-| ----- | ----------- | ------ | -------- |
-| metadata |  | [metav1.ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#listmeta-v1-meta) | false |
-| items |  | [][ThanosReceiveIngestor](#thanosreceiveingestor) | true |
-
-[Back to TOC](#table-of-contents)
-
-## ThanosReceiveIngestorSpec
-
-ThanosReceiveIngestorSpec defines the desired state of a ThanosReceiveIngestor
-
-| Field | Description | Scheme | Required |
-| ----- | ----------- | ------ | -------- |
-| tenants | Tenants if not empty indicates current config is for hard tenants; otherwise, it is for soft tenants. | []string | false |
-| affinity | If specified, the pod's scheduling constraints. | *corev1.Affinity | false |
-| nodeSelector | Define which Nodes the Pods are scheduled on. | map[string]string | false |
-| tolerations | If specified, the pod's tolerations. | []corev1.Toleration | false |
-| resources | Define resources requests and limits for main container. | [corev1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core) | false |
-| replicas | Number of replicas for a thanos component. | *int32 | false |
-| image | Image is the thanos image with tag/version | string | false |
-| logLevel | Log filtering level. Possible options: error, warn, info, debug | string | false |
-| logFormat | Log format to use. Possible options: logfmt or json | string | false |
-| localTsdbRetention | LocalTsdbRetention configs how long to retain raw samples on local storage. | string | false |
-| longTermStore | If specified, the object key of Store for long term storage. | *[ObjectReference](#objectreference) | false |
-| dataVolume | DataVolume specifies how volume shall be used | *[KubernetesVolume](#kubernetesvolume) | false |
-
-[Back to TOC](#table-of-contents)
-
-## ThanosReceiveRouter
-
-
-
-| Field | Description | Scheme | Required |
-| ----- | ----------- | ------ | -------- |
-| affinity | If specified, the pod's scheduling constraints. | *corev1.Affinity | false |
-| nodeSelector | Define which Nodes the Pods are scheduled on. | map[string]string | false |
-| tolerations | If specified, the pod's tolerations. | []corev1.Toleration | false |
-| resources | Define resources requests and limits for main container. | [corev1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core) | false |
-| replicas | Number of replicas for a thanos component. | *int32 | false |
-| image | Image is the thanos image with tag/version | string | false |
-| logLevel | Log filtering level. Possible options: error, warn, info, debug | string | false |
-| logFormat | Log format to use. Possible options: logfmt or json | string | false |
-| replicationFactor | How many times to replicate incoming write requests | *uint64 | false |
-
-[Back to TOC](#table-of-contents)
-
-## ThanosRuler
-
-ThanosRuler is the Schema for the ThanosRuler API
-
-| Field | Description | Scheme | Required |
-| ----- | ----------- | ------ | -------- |
-| metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta) | false |
-| spec |  | [ThanosRulerSpec](#thanosrulerspec) | false |
-| status |  | [ThanosRulerStatus](#thanosrulerstatus) | false |
-
-[Back to TOC](#table-of-contents)
-
-## ThanosRulerList
-
-ThanosRulerList contains a list of ThanosRuler
-
-| Field | Description | Scheme | Required |
-| ----- | ----------- | ------ | -------- |
-| metadata |  | [metav1.ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#listmeta-v1-meta) | false |
-| items |  | [][ThanosRuler](#thanosruler) | true |
-
-[Back to TOC](#table-of-contents)
-
-## ThanosRulerSpec
-
-ThanosRulerSpec defines the desired state of a ThanosRuler
-
-| Field | Description | Scheme | Required |
-| ----- | ----------- | ------ | -------- |
-| affinity | If specified, the pod's scheduling constraints. | *corev1.Affinity | false |
-| nodeSelector | Define which Nodes the Pods are scheduled on. | map[string]string | false |
-| tolerations | If specified, the pod's tolerations. | []corev1.Toleration | false |
-| resources | Define resources requests and limits for main container. | [corev1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core) | false |
-| replicas | Number of replicas for a thanos component. | *int32 | false |
-| image | Image is the thanos image with tag/version | string | false |
-| logLevel | Log filtering level. Possible options: error, warn, info, debug | string | false |
-| logFormat | Log format to use. Possible options: logfmt or json | string | false |
-| alertingRuleSelector | AlertingRules to be selected for alerting. | *[metav1.LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#labelselector-v1-meta) | false |
-| alertingRuleNamespaceSelector | Namespaces to be selected for AlertingRules discovery. If nil, only check own namespace. | *[metav1.LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#labelselector-v1-meta) | false |
-| ruleSelector | A label selector to select which PrometheusRules to mount for alerting and recording. | *[metav1.LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#labelselector-v1-meta) | false |
-| ruleNamespaceSelector | Namespaces to be selected for Rules discovery. If unspecified, only the same namespace as the ThanosRuler object is in is used. | *[metav1.LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#labelselector-v1-meta) | false |
-| alertmanagersUrl | Define URLs to send alerts to Alertmanager.  For Thanos v0.10.0 and higher, AlertManagersConfig should be used instead.  Note: this field will be ignored if AlertManagersConfig is specified. Maps to the `alertmanagers.url` arg. | []string | false |
-| alertmanagersConfig | Define configuration for connecting to alertmanager.  Only available with thanos v0.10.0 and higher.  Maps to the `alertmanagers.config` arg. | *corev1.SecretKeySelector | false |
-| dataVolume | DataVolume specifies how volume shall be used | *[KubernetesVolume](#kubernetesvolume) | false |
-
-[Back to TOC](#table-of-contents)
-
-## ThanosStore
-
-
-
-| Field | Description | Scheme | Required |
-| ----- | ----------- | ------ | -------- |
-| storeGateway | Thanos Store Gateway will be selected as query backends by Service. | *[ThanosStoreGateway](#thanosstoregateway) | false |
-| compact | Thanos Compact as object storage data compactor and lifecycle manager. | *[ThanosCompact](#thanoscompact) | false |
-
-[Back to TOC](#table-of-contents)
-
-## ThanosStoreGateway
-
-
-
-| Field | Description | Scheme | Required |
-| ----- | ----------- | ------ | -------- |
-| affinity | If specified, the pod's scheduling constraints. | *corev1.Affinity | false |
-| nodeSelector | Define which Nodes the Pods are scheduled on. | map[string]string | false |
-| tolerations | If specified, the pod's tolerations. | []corev1.Toleration | false |
-| resources | Define resources requests and limits for main container. | [corev1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core) | false |
-| replicas | Number of replicas for a thanos component | *int32 | false |
-| image | Image is the thanos image with tag/version | string | false |
-| logLevel | Log filtering level. Possible options: error, warn, info, debug | string | false |
-| logFormat | Log format to use. Possible options: logfmt or json | string | false |
+| storage |  | *[ObjectReference](#objectreference) | false |
 | minTime | MinTime specifies start of time range limit to serve | string | false |
 | maxTime | MaxTime specifies end of time range limit to serve | string | false |
+| indexCacheConfig | IndexCacheConfig contains index cache configuration. | *[IndexCacheConfig](#indexcacheconfig) | false |
+| flags | Flags is a list of key/value that could be used to set strategy parameters. | map[string]string | false |
 | dataVolume | DataVolume specifies how volume shall be used | *[KubernetesVolume](#kubernetesvolume) | false |
+| scaler |  | *[AutoScaler](#autoscaler) | false |
 
 [Back to TOC](#table-of-contents)
+
+## S3
+
+Config stores the configuration for s3 bucket.
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| bucket |  | string | true |
+| endpoint |  | string | true |
+| region |  | string | false |
+| awsSdkAuth |  | bool | false |
+| accessKeyRef |  | *corev1.SecretKeySelector | true |
+| insecure |  | bool | false |
+| signatureVersion2 |  | bool | false |
+| secretKeyRef |  | *corev1.SecretKeySelector | true |
+| putUserMetadata |  | map[string]string | false |
+| httpConfig |  | [S3HTTPConfig](#s3httpconfig) | false |
+| trace |  | [S3TraceConfig](#s3traceconfig) | false |
+| listObjectsVersion |  | string | false |
+| partSize | PartSize used for multipart upload. Only used if uploaded object size is known and larger than configured PartSize. NOTE we need to make sure this number does not produce more parts than 10 000. | uint64 | false |
+| sseConfig |  | [S3SSEConfig](#s3sseconfig) | false |
+| stsEndpoint |  | string | false |
+
+[Back to TOC](#table-of-contents)
+
+## S3HTTPConfig
+
+S3HTTPConfig stores the http.Transport configuration for the s3 minio client.
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| idleConnTimeout |  | model.Duration | false |
+| responseHeaderTimeout |  | model.Duration | false |
+| insecureSkipVerify |  | bool | false |
+| tlsHandshakeTimeout |  | model.Duration | false |
+| expectContinueTimeout |  | model.Duration | false |
+| maxIdleConns |  | int | false |
+| maxIdleConnsPerHost |  | int | false |
+| maxConnsPerHost |  | int | false |
+| tlsConfig |  | [TLSConfig](#tlsconfig) | false |
+
+[Back to TOC](#table-of-contents)
+
+## S3SSEConfig
+
+S3SSEConfig deals with the configuration of SSE for Minio. The following options are valid: kmsencryptioncontext == https://docs.aws.amazon.com/kms/latest/developerguide/services-s3.html#s3-encryption-context
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| type |  | string | false |
+| kmsKeyId |  | string | false |
+| kmsEncryptionContext |  | map[string]string | false |
+| encryptionKey |  | string | false |
+
+[Back to TOC](#table-of-contents)
+
+## S3TraceConfig
+
+
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| enable |  | bool | false |
+
+[Back to TOC](#table-of-contents)
+
+## Storage
+
+
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta) | false |
+| spec |  | [StorageSpec](#storagespec) | false |
+| status |  | [StorageStatus](#storagestatus) | false |
+
+[Back to TOC](#table-of-contents)
+
+## StorageList
+
+
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| metadata |  | [metav1.ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#listmeta-v1-meta) | false |
+| items |  | [][Storage](#storage) | true |
+
+[Back to TOC](#table-of-contents)
+
+## StorageSpec
+
+
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| S3 |  | *[S3](#s3) | false |
+
+[Back to TOC](#table-of-contents)
+
+## TLSConfig
+
+TLSConfig configures the options for TLS connections.
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| caFile | The CA cert to use for the targets. | string | false |
+| certFile | The client cert file for the targets. | string | false |
+| keyFile | The client key file for the targets. | string | false |
+| serverName | Used to verify the hostname for the targets. | string | false |
+| insecureSkipVerify | Disable target certificate validation. | bool | false |
+
+[Back to TOC](#table-of-contents)
+
+
+

--- a/docs/monitoring/examples.md
+++ b/docs/monitoring/examples.md
@@ -2,7 +2,7 @@
 
 Refer to the following example for multi-cluster monitoring of KubeSphere platform.
 
-> Please firstly refer to [here](../README.md#quickstart) to install paodin-controller-manager.
+> Please firstly refer to [here](../README.md#quickstart) to install whizard-controller-manager.
 
 ## Scattered
 
@@ -22,7 +22,7 @@ Follow the following steps to deploy components:
 
   ```shell
   cat <<EOF | kubectl apply -f -
-  apiVersion: monitoring.paodin.io/v1alpha1
+  apiVersion: monitoring.whizard.io/v1alpha1
   kind: Service
   metadata:
     name: scattered
@@ -71,7 +71,7 @@ Follow the following steps to deploy components:
 
   ```shell
   cat <<EOF | kubectl apply -f -
-  apiVersion: monitoring.paodin.io/v1alpha1
+  apiVersion: monitoring.whizard.io/v1alpha1
   kind: Storage
   metadata:
     name: default
@@ -93,7 +93,7 @@ Follow the following steps to deploy components:
 
   ```shell
   cat <<EOF | kubectl apply -f -
-  apiVersion: monitoring.paodin.io/v1alpha1
+  apiVersion: monitoring.whizard.io/v1alpha1
   kind: Service
   metadata:
     name: central
@@ -109,8 +109,8 @@ Follow the following steps to deploy components:
     query:
       replicaLabelNames:
       - prometheus_replica
-      - thanos_receive_replica
-      - thanos_ruler_replica
+      - receive_replica
+      - ruler_replica
     router:
       replicationFactor: 2
     queryFrontend:
@@ -128,11 +128,11 @@ Follow the following steps to deploy components:
   &#8195;&#8195;Automatically generated Tenant CR looks like this.
 
 ```yaml
-apiVersion: monitoring.paodin.io/v1alpha1
+apiVersion: monitoring.whizard.io/v1alpha1
 kind: Tenant
 metadata:
   labels:
-    monitoring.paodin.io/service: kubesphere-monitoring-system.central
+    monitoring.whizard.io/service: kubesphere-monitoring-system.central
   name: host
 spec:
   storage:
@@ -155,24 +155,24 @@ cat <<EOF | kubectl apply -f -
   kind: Deployment
   metadata:
     labels:
-      app.kubernetes.io/name: paodin-monitoring-agent-proxy
-      component: paodin
-    name: paodin-monitoring-agent-proxy
+      app.kubernetes.io/name: whizard-monitoring-agent-proxy
+      component: whizard
+    name: whizard-monitoring-agent-proxy
     namespace: kubesphere-monitoring-system
   spec:
     replicas: 1
     selector:
       matchLabels:
-        app.kubernetes.io/name: paodin-monitoring-agent-proxy
-        component: paodin
+        app.kubernetes.io/name: whizard-monitoring-agent-proxy
+        component: whizard
     template:
       metadata:
         labels:
-          app.kubernetes.io/name: paodin-monitoring-agent-proxy
-          component: paodin
+          app.kubernetes.io/name: whizard-monitoring-agent-proxy
+          component: whizard
       spec:
         containers:
-        - image: kubesphere/paodin-monitoring-agent-proxy:latest
+        - image: kubesphere/whizard-monitoring-agent-proxy:latest
           args: 
             - --gateway.address="<gateway_address>"
             - --tenant="<cluster_name>"
@@ -192,14 +192,14 @@ cat <<EOF | kubectl apply -f -
   kind: Service
   metadata:
     labels:
-      app.kubernetes.io/name: paodin-monitoring-agent-proxy
-      component: paodin
-    name: paodin-monitoring-agent-proxy
+      app.kubernetes.io/name: whizard-monitoring-agent-proxy
+      component: whizard
+    name: whizard-monitoring-agent-proxy
     namespace: kubesphere-monitoring-system
   spec:
     selector:
-      app.kubernetes.io/name: paodin-monitoring-agent-proxy
-      component: paodin
+      app.kubernetes.io/name: whizard-monitoring-agent-proxy
+      component: whizard
     ports:
     - port: 9090
       protocol: TCP
@@ -211,7 +211,7 @@ EOF
 5. On all clusters, configure Prometheus to write to agent-proxy:  
 
   ```shell
-  kubectl -n kubesphere-monitoring-system patch prometheus k8s --patch='{"spec":{"remoteWrite":[{"url":"http://paodin-monitoring-agent-proxy.kubesphere-monitoring-system.svc:9090/api/v1/receive"}]}}' --type=merge
+  kubectl -n kubesphere-monitoring-system patch prometheus k8s --patch='{"spec":{"remoteWrite":[{"url":"http://whizard-monitoring-agent-proxy.kubesphere-monitoring-system.svc:9090/api/v1/receive"}]}}' --type=merge
   ```
 
 6. On member clusters, configure ks-apiserver to read from agent-proxy:  
@@ -224,12 +224,12 @@ EOF
     kubesphere.yaml: |
       ...
       monitoring:
-        endpoint: http://paodin-monitoring-agent-proxy.kubesphere-monitoring-system.svc:9090
+        endpoint: http://whizard-monitoring-agent-proxy.kubesphere-monitoring-system.svc:9090
         ...
       ...
   ...
   ```
 
-7. On host cluster, configure ks-apiserver to read from paodin-apiserver
+7. On host cluster, configure ks-apiserver to read from whizard-apiserver
 
   todo;

--- a/docs/proposals/2022-07-auto-scaling.md
+++ b/docs/proposals/2022-07-auto-scaling.md
@@ -35,7 +35,7 @@ When a delete event is received, the tenant is removed from the Ingestor and the
 When ingestor's Tennats are empty, it will be reclaimed:
 
 * When the tenant is empty condition is triggered, the ingestor is not deleted immediately.
-* First add two labels to ingestor, "monitoring.paodin.io/ingestor-state=deleting" and "monitoring.paodin.io/ingestor-deleting-time=`time.Now() + defaultIngestorRetentionPeriod`".
+* First add two labels to ingestor, "monitoring.whizard.io/ingestor-state=deleting" and "monitoring.whizard.io/ingestor-deleting-time=`time.Now() + defaultIngestorRetentionPeriod`".
 * If it is used by another tenant during the `defaultIngestorRetentionPeriod`, the label is updated.
 * If tenant is not in use after `defaultIngestorRetentionPeriod`, delete it.
 * `defaultIngestorRetentionPeriod` can be updated from the command line or configuration file, The default 3 h.

--- a/docs/proposals/2022-07-tenant.md
+++ b/docs/proposals/2022-07-tenant.md
@@ -7,7 +7,7 @@ Add CRD to Tenant to decouple Thanos resources from object storage. It also deco
 ## Goals
 
 * Allow configuration of the Service/Storage field of Tenant
-* Autoscale ThanosReceiveIngestor/ThanosRuler based on the number of Tenants
+* Autoscale Ingester/Ruler based on the number of Tenants
 * Decouples kubesphere cluster from Thanos Receive Hard Tenant
 * View the tenant's Thanos resources by using the Status field
 
@@ -16,12 +16,12 @@ Add CRD to Tenant to decouple Thanos resources from object storage. It also deco
 ### Tenant CRD
 
 ```yaml
-apiVersion: monitoring.paodin.io/v1alpha1
+apiVersion: monitoring.whizard.io/v1alpha1
 kind: Tenant
 metadata:
   name: test
   labels:
-    monitoring.paodin.io/service: kubesphere-monitoring-system.central
+    monitoring.whizard.io/service: kubesphere-monitoring-system.central
 spec:
   tenant: test
   storage:
@@ -39,7 +39,7 @@ status:
 
 ### Tenant Service
 
-The tenant's Service is allowed to be configured in the `tenant.metadata.labels[monitoring.paodin.io/service]` field. If it is empty, the tenant is not associated with any Thanos resources.
+The tenant's Service is allowed to be configured in the `tenant.metadata.labels[monitoring.whizard.io/service]` field. If it is empty, the tenant is not associated with any Thanos resources.
 
 
 ### Tenant Storage

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kubesphere/paodin
+module github.com/kubesphere/whizard
 
 go 1.17
 

--- a/hack/generate_client.sh
+++ b/hack/generate_client.sh
@@ -5,6 +5,6 @@ set -e
 GV="$1"
 
 rm -rf ./pkg/client/clientset ./pkg/client/informers ./pkg/client/listers
-./hack/generate_group.sh "client,lister,informer" github.com/kubesphere/paodin/pkg/client github.com/kubesphere/paodin/pkg/api "${GV}" --output-base=./  -h "$PWD/hack/boilerplate.go.txt"
-mv github.com/kubesphere/paodin/pkg/client/* ./pkg/client/
+./hack/generate_group.sh "client,lister,informer" github.com/kubesphere/whizard/pkg/client github.com/kubesphere/whizard/pkg/api "${GV}" --output-base=./  -h "$PWD/hack/boilerplate.go.txt"
+mv github.com/kubesphere/whizard/pkg/client/* ./pkg/client/
 rm -rf ./github.com

--- a/pkg/api/monitoring/v1alpha1/groupversion_info.go
+++ b/pkg/api/monitoring/v1alpha1/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the monitoring v1alpha1 API group
 //+kubebuilder:object:generate=true
-//+groupName=monitoring.paodin.io
+//+groupName=monitoring.whizard.io
 package v1alpha1
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	SchemeGroupVersion = schema.GroupVersion{Group: "monitoring.paodin.io", Version: "v1alpha1"}
+	SchemeGroupVersion = schema.GroupVersion{Group: "monitoring.whizard.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}

--- a/pkg/api/monitoring/v1alpha1/service_types.go
+++ b/pkg/api/monitoring/v1alpha1/service_types.go
@@ -30,14 +30,6 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-const (
-	FinalizerMonitoringPaodinDeletePVC = "finalizers.monitoring.paodin.io/deletePVC"
-
-	DefaultTenantHeader    = "PAODIN-TENANT"
-	DefaultTenantId        = "default-tenant"
-	DefaultTenantLabelName = "tenant_id"
-)
-
 // ServiceSpec defines the desired state of a Service
 type ServiceSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
@@ -52,7 +44,7 @@ type ServiceSpec struct {
 
 	Storage *ObjectReference `json:"storage,omitempty"`
 
-	// Gateway to proxy and auth requests to Query and Router defined in Thanos.
+	// Gateway to proxy and auth requests to Query and Router.
 	Gateway *Gateway `json:"gateway,omitempty"`
 
 	// Query component querys from the backends such as Ingester and Store by automated discovery.
@@ -103,7 +95,7 @@ type Query struct {
 	// Number of replicas for a component
 	Replicas *int32 `json:"replicas,omitempty"`
 
-	// Image is the thanos image with tag/version
+	// Image is the image with tag/version
 	Image string `json:"image,omitempty"`
 	// Log filtering level. Possible options: error, warn, info, debug
 	LogLevel string `json:"logLevel,omitempty"`
@@ -126,13 +118,12 @@ type Query struct {
 
 type QueryStores struct {
 	// Address is the addresses of StoreApi server, which may be prefixed with 'dns+' or 'dnssrv+' to detect StoreAPI servers through respective DNS lookups.
-	// For more info, see https://thanos.io/tip/thanos/service-discovery.md/#dns-service-discovery
 	Addresses []string `json:"addresses,omitempty"`
 	// Secret containing the CA cert to use for StoreApi connections
 	CASecret *corev1.SecretKeySelector `json:"caSecret,omitempty"`
 }
 
-// EnvoySpec defines the desired state of envoy proxy sidecar which delegates requests to the secure thanos stores
+// EnvoySpec defines the desired state of envoy proxy sidecar which delegates requests to the secure stores
 type EnvoySpec struct {
 	// Image is the envoy image with tag/version
 	Image string `json:"image,omitempty"`
@@ -152,7 +143,7 @@ type Router struct {
 	// Number of replicas for a component.
 	Replicas *int32 `json:"replicas,omitempty"`
 
-	// Image is the thanos image with tag/version
+	// Image is the image with tag/version
 	Image string `json:"image,omitempty"`
 	// Log filtering level. Possible options: error, warn, info, debug
 	LogLevel string `json:"logLevel,omitempty"`
@@ -178,7 +169,7 @@ type QueryFrontend struct {
 	// Number of replicas for a component
 	Replicas *int32 `json:"replicas,omitempty"`
 
-	// Image is the thanos image with tag/version
+	// Image is the image with tag/version
 	Image string `json:"image,omitempty"`
 	// Log filtering level. Possible options: error, warn, info, debug
 	LogLevel string `json:"logLevel,omitempty"`
@@ -310,7 +301,7 @@ type StoreSpec struct {
 	// Number of replicas for a component
 	Replicas *int32 `json:"replicas,omitempty"`
 
-	// Image is the thanos image with tag/version
+	// Image is the image with tag/version
 	Image string `json:"image,omitempty"`
 	// Image pull policy.
 	// One of Always, Never, IfNotPresent.
@@ -382,7 +373,7 @@ type CompactorSpec struct {
 	// Number of replicas for a component
 	Replicas *int32 `json:"replicas,omitempty"`
 
-	// Image is the thanos image with tag/version
+	// Image is the image with tag/version
 	Image string `json:"image,omitempty"`
 	// Image pull policy.
 	// One of Always, Never, IfNotPresent.
@@ -456,7 +447,7 @@ type IngesterSpec struct {
 	// Number of replicas for a component.
 	Replicas *int32 `json:"replicas,omitempty"`
 
-	// Image is the thanos image with tag/version
+	// Image is the image with tag/version
 	Image string `json:"image,omitempty"`
 	// Log filtering level. Possible options: error, warn, info, debug
 	LogLevel string `json:"logLevel,omitempty"`
@@ -522,7 +513,7 @@ type RulerSpec struct {
 	// Number of replicas for a component.
 	Replicas *int32 `json:"replicas,omitempty"`
 
-	// Image is the thanos image with tag/version
+	// Image is the image with tag/version
 	Image string `json:"image,omitempty"`
 	// Log filtering level. Possible options: error, warn, info, debug
 	LogLevel string `json:"logLevel,omitempty"`
@@ -547,18 +538,12 @@ type RulerSpec struct {
 	Tenant string `json:"tenant,omitempty"`
 
 	// Labels configure the external label pairs to Ruler. A default replica label
-	// `thanos_ruler_replica` will be always added  as a label with the value of the pod's name and it will be dropped in the alerts.
+	// `ruler_replica` will be always added  as a label with the value of the pod's name and it will be dropped in the alerts.
 	Labels map[string]string `json:"labels,omitempty"`
 	// AlertDropLabels configure the label names which should be dropped in Ruler alerts.
-	// The replica label `thanos_ruler_replica` will always be dropped in alerts.
+	// The replica label `ruler_replica` will always be dropped in alerts.
 	AlertDropLabels []string `json:"alertDropLabels,omitempty"`
-	// Define URLs to send alerts to Alertmanager.  For Thanos v0.10.0 and higher,
-	// AlertManagersConfig should be used instead.  Note: this field will be ignored
-	// if AlertManagersConfig is specified.
-	// Maps to the `alertmanagers.url` arg.
-	AlertManagersURL []string `json:"alertmanagersUrl,omitempty"`
-	// Define configuration for connecting to alertmanager.  Only available with thanos v0.10.0
-	// and higher.  Maps to the `alertmanagers.config` arg.
+	// Define configuration for connecting to alertmanager. Maps to the `alertmanagers.config` arg.
 	AlertManagersConfig *corev1.SecretKeySelector `json:"alertmanagersConfig,omitempty"`
 	// Interval between consecutive evaluations. Default: `30s`
 	// +kubebuilder:default:="30s"
@@ -689,7 +674,7 @@ func init() {
 
 func ManagedLabelByService(service metav1.Object) map[string]string {
 	return map[string]string{
-		"monitoring.paodin.io/service": service.GetNamespace() + "." + service.GetName(),
+		"monitoring.whizard.io/service": service.GetNamespace() + "." + service.GetName(),
 	}
 }
 
@@ -699,7 +684,7 @@ func ServiceNamespacedName(managedByService metav1.Object) *types.NamespacedName
 		return nil
 	}
 
-	namespacedName := ls["monitoring.paodin.io/service"]
+	namespacedName := ls["monitoring.whizard.io/service"]
 	arr := strings.Split(namespacedName, ".")
 	if len(arr) != 2 {
 		return nil
@@ -713,7 +698,7 @@ func ServiceNamespacedName(managedByService metav1.Object) *types.NamespacedName
 
 func ManagedLabelByRuleGroup(ruleGroup metav1.Object) map[string]string {
 	return map[string]string{
-		"monitoring.paodin.io/rule-group": ruleGroup.GetName(),
+		"monitoring.whizard.io/rule-group": ruleGroup.GetName(),
 	}
 }
 
@@ -722,5 +707,5 @@ func RuleGroupName(managedByRuleGroup metav1.Object) string {
 	if ls == nil {
 		return ""
 	}
-	return ls["monitoring.paodin.io/rule-group"]
+	return ls["monitoring.whizard.io/rule-group"]
 }

--- a/pkg/api/monitoring/v1alpha1/storage_types.go
+++ b/pkg/api/monitoring/v1alpha1/storage_types.go
@@ -19,21 +19,11 @@ package v1alpha1
 import (
 	"strings"
 
+	"github.com/kubesphere/whizard/pkg/constants"
 	"github.com/prometheus/common/model"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-)
-
-const (
-	MonitoringPaodinService = "monitoring.paodin.io/service"
-	MonitoringPaodinStorage = "monitoring.paodin.io/storage"
-	MonitoringPaodinTenant  = "monitoring.paodin.io/tenant"
-
-	FinalizerMonitoringIngester  = "finalizers.monitoring.paodin.io/ingester"
-	FinalizerMonitoringCompactor = "finalizers.monitoring.paodin.io/compactor"
-
-	MonitoringLocalStorage = "default_storage.local"
 )
 
 type StorageSpec struct {
@@ -130,7 +120,7 @@ type StorageList struct {
 
 func ManagedLabelByStorage(storage metav1.Object) map[string]string {
 	return map[string]string{
-		MonitoringPaodinStorage: storage.GetNamespace() + "." + storage.GetName(),
+		constants.StorageLabelKey: storage.GetNamespace() + "." + storage.GetName(),
 	}
 }
 
@@ -140,7 +130,7 @@ func StorageNamespacedName(managedByStorage metav1.Object) *types.NamespacedName
 		return nil
 	}
 
-	namespacedName := ls[MonitoringPaodinStorage]
+	namespacedName := ls[constants.StorageLabelKey]
 	arr := strings.Split(namespacedName, ".")
 	if len(arr) != 2 {
 		return nil

--- a/pkg/api/monitoring/v1alpha1/tenant_types.go
+++ b/pkg/api/monitoring/v1alpha1/tenant_types.go
@@ -71,8 +71,8 @@ type TenantList struct {
 
 	type TenantGroupSpec struct {
 		TenantGroupId string           `json:"tenantGroupId"`
-		PaodinService *ObjectReference `json:"paodinService"`
-		PaodinStorage *ObjectReference `json:"paodinStorage"`
+		WhizardService *ObjectReference `json:"whizardService"`
+		WhizardStorage *ObjectReference `json:"whizardStorage"`
 	}
 
 	type TenantGroupStatus struct {

--- a/pkg/api/monitoring/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/monitoring/v1alpha1/zz_generated.deepcopy.go
@@ -1031,11 +1031,6 @@ func (in *RulerSpec) DeepCopyInto(out *RulerSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.AlertManagersURL != nil {
-		in, out := &in.AlertManagersURL, &out.AlertManagersURL
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	if in.AlertManagersConfig != nil {
 		in, out := &in.AlertManagersConfig, &out.AlertManagersConfig
 		*out = new(v1.SecretKeySelector)

--- a/pkg/apis/addtoscheme_monitoring_v1alpha1.go
+++ b/pkg/apis/addtoscheme_monitoring_v1alpha1.go
@@ -1,7 +1,7 @@
 package apis
 
 import (
-	"github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
 )
 
 func init() {

--- a/pkg/apis/apis.go
+++ b/pkg/apis/apis.go
@@ -1,4 +1,4 @@
-// Package apis contains Paodin API groups.
+// Package apis contains Whizard API groups.
 package apis
 
 import (

--- a/pkg/constants/constans.go
+++ b/pkg/constants/constans.go
@@ -1,0 +1,46 @@
+package constants
+
+const (
+	DefaultTenantHeader    = "WHIZARD-TENANT"
+	DefaultTenantId        = "default-tenant"
+	DefaultTenantLabelName = "tenant_id"
+
+	ServiceLabelKey = "monitoring.whizard.io/service"
+	StorageLabelKey = "monitoring.whizard.io/storage"
+	TenantLabelKey  = "monitoring.whizard.io/tenant"
+
+	FinalizerIngester  = "finalizers.monitoring.whizard.io/ingester"
+	FinalizerCompactor = "finalizers.monitoring.whizard.io/compactor"
+	FinalizerDeletePVC = "finalizers.monitoring.whizard.io/deletePVC"
+
+	LocalStorage = "default_storage.local"
+
+	GRPCPort        = 10901
+	HTTPPort        = 10902
+	RemoteWritePort = 19291
+
+	GRPCPortName        = "grpc"
+	HTTPPortName        = "http"
+	RemoteWritePortName = "remote-write"
+
+	ReceiveReplicaLabelName = "receive_replica"
+	RulerReplicaLabelName   = "ruler_replica"
+
+	AppNameGateway       = "whizard-monitoring-gateway"
+	AppNameQuery         = "query"
+	AppNameQueryFrontend = "query-frontend"
+	AppNameRouter        = "router"
+	AppNameIngester      = "ingester"
+	AppNameRuler         = "ruler"
+	AppNameStore         = "store"
+	AppNameCompactor     = "compactor"
+
+	ServiceNameSuffix = "operated"
+
+	LabelNameAppName      = "app.kubernetes.io/name"
+	LabelNameAppManagedBy = "app.kubernetes.io/managed-by"
+	LabelNameAppPartOf    = "app.kubernetes.io/part-of"
+
+	LabelNameIngesterState        = "monitoring.whizard.io/ingester-state"
+	LabelNameIngesterDeletingTime = "monitoring.whizard.io/ingester-deleting-time"
+)

--- a/pkg/controllers/config/config.go
+++ b/pkg/controllers/config/config.go
@@ -10,8 +10,8 @@ import (
 	"github.com/spf13/viper"
 	"k8s.io/klog/v2"
 
-	"github.com/kubesphere/paodin/pkg/client/k8s"
-	monitoring "github.com/kubesphere/paodin/pkg/controllers/monitoring/options"
+	"github.com/kubesphere/whizard/pkg/client/k8s"
+	monitoring "github.com/kubesphere/whizard/pkg/controllers/monitoring/options"
 )
 
 var (
@@ -21,9 +21,9 @@ var (
 
 const (
 	// defaultConfigurationName is the default name of configuration
-	defaultConfigurationName = "paodin"
+	defaultConfigurationName = "whizard"
 	// defaultConfigurationPath the default location of the configuration file
-	defaultConfigurationPath = "/etc/paodin"
+	defaultConfigurationPath = "/etc/whizard"
 )
 
 type config struct {
@@ -69,7 +69,7 @@ func defaultConfig() *config {
 	viper.AddConfigPath(".")
 
 	// Load from Environment variables
-	viper.SetEnvPrefix("paodin")
+	viper.SetEnvPrefix("whizard")
 	viper.AutomaticEnv()
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 

--- a/pkg/controllers/monitoring/cluster_controller.go
+++ b/pkg/controllers/monitoring/cluster_controller.go
@@ -19,21 +19,21 @@ package monitoring
 import (
 	"context"
 
+	monitoringv1alpha1 "github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/util"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
+	clusterv1alpha1 "kubesphere.io/api/cluster/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	monitoringv1alpha1 "github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
-	"github.com/kubesphere/paodin/pkg/util"
-	clusterv1alpha1 "kubesphere.io/api/cluster/v1alpha1"
 )
 
 // ClusterReconciler reconciles a Service object
@@ -45,7 +45,7 @@ type ClusterReconciler struct {
 }
 
 //+kubebuilder:rbac:groups=cluster.kubesphere.io,resources=clusters,verbs=get;list;watch
-//+kubebuilder:rbac:groups=monitoring.paodin.io,resources=tenants,verbs=verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=tenants,verbs=verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -105,7 +105,7 @@ func (r *ClusterReconciler) mapToTenantFunc(o client.Object) []reconcile.Request
 func (r *ClusterReconciler) createTenantInstance(cluster *clusterv1alpha1.Cluster) *monitoringv1alpha1.Tenant {
 
 	label := make(map[string]string, 1)
-	label[monitoringv1alpha1.MonitoringPaodinService] = r.KubesphereAdapterDefaultService
+	label[constants.ServiceLabelKey] = r.KubesphereAdapterDefaultService
 	return &monitoringv1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   cluster.Name,

--- a/pkg/controllers/monitoring/ingestor_controller.go
+++ b/pkg/controllers/monitoring/ingestor_controller.go
@@ -22,6 +22,12 @@ import (
 	"strconv"
 	"time"
 
+	monitoringv1alpha1 "github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/options"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources/ingester"
+	"github.com/prometheus/common/model"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -33,12 +39,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-
-	monitoringv1alpha1 "github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/options"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources/ingester"
-	"github.com/prometheus/common/model"
 )
 
 // IngesterReconciler reconciles a Ingester object
@@ -49,10 +49,10 @@ type IngesterReconciler struct {
 	Context context.Context
 }
 
-//+kubebuilder:rbac:groups=monitoring.paodin.io,resources=ingesters,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=monitoring.paodin.io,resources=ingesters/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=monitoring.paodin.io,resources=ingesters/finalizers,verbs=update
-//+kubebuilder:rbac:groups=monitoring.paodin.io,resources=services,verbs=get;list;watch
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=ingesters,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=ingesters/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=ingesters/finalizers,verbs=update
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=services,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 
@@ -80,8 +80,8 @@ func (r *IngesterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	// recycle ingester by using the RequeueAfter event
-	if v, ok := instance.Annotations[resources.LabelNameIngesterState]; ok && v == "deleting" && len(instance.Spec.Tenants) == 0 {
-		if deletingTime, ok := instance.Annotations[resources.LabelNameIngesterDeletingTime]; ok {
+	if v, ok := instance.Annotations[constants.LabelNameIngesterState]; ok && v == "deleting" && len(instance.Spec.Tenants) == 0 {
+		if deletingTime, ok := instance.Annotations[constants.LabelNameIngesterDeletingTime]; ok {
 			i, err := strconv.ParseInt(deletingTime, 10, 64)
 			if err == nil {
 				d := time.Since(time.Unix(i, 0))
@@ -163,7 +163,7 @@ func CreateIngesterDefaulterValidator(opt options.Options) IngesterDefaulterVali
 		}
 
 		if ingester.Spec.Image == "" {
-			ingester.Spec.Image = opt.ThanosImage
+			ingester.Spec.Image = opt.WhizardImage
 		}
 		if ingester.Spec.Replicas == nil || *ingester.Spec.Replicas < 0 {
 			ingester.Spec.Replicas = &replicas

--- a/pkg/controllers/monitoring/options/options.go
+++ b/pkg/controllers/monitoring/options/options.go
@@ -3,8 +3,8 @@ package options
 import (
 	"time"
 
-	"github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
-	"github.com/kubesphere/paodin/pkg/util"
+	"github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/util"
 	"github.com/spf13/pflag"
 	"k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
@@ -12,13 +12,13 @@ import (
 )
 
 const (
-	ThanosDefaultImage                   = "thanosio/thanos:v0.26.0"
-	EnvoyDefaultImage                    = "envoyproxy/envoy:v1.20.2"
-	PaodinMonitoringGatewayDefaultImage  = "kubesphere/paodin-monitoring-gateway:latest"
-	PaodinDefaultService                 = "kubesphere-monitoring-system.central"
-	PaodinDefaultTenantsPerIngester      = 3
-	PaodinDefaultIngesterRetentionPeriod = time.Hour * 3
-	PaodinDefaultTenantsPerCompactor     = 10
+	DefaultWhizardImage            = "thanosio/thanos:v0.26.0"
+	DefaultEnvoyImage              = "envoyproxy/envoy:v1.20.2"
+	DefaultGatewayImage            = "kubesphere/whizard-monitoring-gateway:latest"
+	DefaultService                 = "kubesphere-monitoring-system.central"
+	DefaultTenantsPerIngester      = 3
+	DefaultIngesterRetentionPeriod = time.Hour * 3
+	DefaultTenantsPerCompactor     = 10
 
 	DefaultStoreMinReplicas = 2
 	DefaultStoreMaxReplicas = 20
@@ -33,7 +33,7 @@ var PrometheusConfigReloaderDefaultConfig = PrometheusConfigReloaderConfig{
 }
 
 var RulerQueryProxyDefaultConfig = RulerQueryProxyConfig{
-	Image:         PaodinMonitoringGatewayDefaultImage,
+	Image:         DefaultGatewayImage,
 	CPURequest:    "100m",
 	MemoryRequest: "50Mi",
 	CPULimit:      "100m",
@@ -135,7 +135,7 @@ func (o *CommonOptions) ApplyTo(options *CommonOptions) {
 }
 
 func (o *CommonOptions) AddFlags(fs *pflag.FlagSet, c *CommonOptions, prefix string) {
-	fs.StringVar(&c.Image, prefix+".image", c.Image, "Thanos image with tag/version")
+	fs.StringVar(&c.Image, prefix+".image", c.Image, "Image with tag/version")
 	fs.StringVar(&c.LogLevel, prefix+".log.level", c.LogLevel, "Log filtering level")
 	fs.StringVar(&c.LogFormat, prefix+".log.format", c.LogLevel, "Log format to use. Possible options: logfmt or json")
 }
@@ -263,7 +263,7 @@ func defaultStoreOptions() StoreOptions {
 
 	return StoreOptions{
 		CommonOptions: CommonOptions{
-			Image: ThanosDefaultImage,
+			Image: DefaultWhizardImage,
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("100m"),
@@ -355,9 +355,9 @@ func (o *StoreOptions) AddFlags(_ *pflag.FlagSet, _ *StoreOptions) {
 }
 
 type Options struct {
-	ThanosImage                  string `json:"thanosImage,omitempty" yaml:"thanosImage,omitempty"`
-	EnvoyImage                   string `json:"envoyImage,omitempty" yaml:"envoyImage,omitempty"`
-	PaodinMonitoringGatewayImage string `json:"paodinMonitoringGatewayImage,omitempty" yaml:"paodinMonitoringGatewayImage,omitempty"`
+	WhizardImage string `json:"whizardImage,omitempty" yaml:"whizardImage,omitempty"`
+	EnvoyImage   string `json:"envoyImage,omitempty" yaml:"envoyImage,omitempty"`
+	GatewayImage string `json:"gatewayImage,omitempty" yaml:"gGatewayImage,omitempty"`
 
 	EnableKubeSphereAdapter        bool          `json:"enableKubeSphereAdapter,omitempty" yaml:"enableKubeSphereAdapter,omitempty"`
 	KubeSphereAdapterService       string        `json:"kubeSphereAdapterService,omitempty" yaml:"kubeSphereAdapterService,omitempty"`
@@ -373,17 +373,17 @@ type Options struct {
 
 func NewOptions() *Options {
 	return &Options{
-		ThanosImage:                    ThanosDefaultImage,
-		EnvoyImage:                     EnvoyDefaultImage,
-		PaodinMonitoringGatewayImage:   PaodinMonitoringGatewayDefaultImage,
-		DefaultTenantsPerIngester:      PaodinDefaultTenantsPerIngester,
-		DefaultIngesterRetentionPeriod: PaodinDefaultIngesterRetentionPeriod,
+		WhizardImage:                   DefaultWhizardImage,
+		EnvoyImage:                     DefaultEnvoyImage,
+		GatewayImage:                   DefaultGatewayImage,
+		DefaultTenantsPerIngester:      DefaultTenantsPerIngester,
+		DefaultIngesterRetentionPeriod: DefaultIngesterRetentionPeriod,
 		EnableKubeSphereAdapter:        true,
-		KubeSphereAdapterService:       PaodinDefaultService,
+		KubeSphereAdapterService:       DefaultService,
 		PrometheusConfigReloader:       PrometheusConfigReloaderDefaultConfig,
 		RulerQueryProxy:                RulerQueryProxyDefaultConfig,
 		Compactor: CompactorOptions{
-			DefaultTenantsPerCompactor: PaodinDefaultTenantsPerCompactor,
+			DefaultTenantsPerCompactor: DefaultTenantsPerCompactor,
 		},
 		Store: defaultStoreOptions(),
 	}
@@ -398,14 +398,14 @@ func (o *Options) Validate() []error {
 }
 
 func (o *Options) ApplyTo(options *Options) {
-	if o.ThanosImage != "" {
-		options.ThanosImage = o.ThanosImage
+	if o.WhizardImage != "" {
+		options.WhizardImage = o.WhizardImage
 	}
 	if o.EnvoyImage != "" {
 		options.EnvoyImage = o.EnvoyImage
 	}
-	if o.PaodinMonitoringGatewayImage != "" {
-		options.PaodinMonitoringGatewayImage = o.PaodinMonitoringGatewayImage
+	if o.GatewayImage != "" {
+		options.GatewayImage = o.GatewayImage
 	}
 	if o.DefaultTenantsPerIngester != 0 {
 		options.DefaultTenantsPerIngester = o.DefaultTenantsPerIngester
@@ -424,13 +424,13 @@ func (o *Options) ApplyTo(options *Options) {
 }
 
 func (o *Options) AddFlags(fs *pflag.FlagSet, c *Options) {
-	fs.StringVar(&c.ThanosImage, "thanos-image", ThanosDefaultImage, "Thanos image with tag/version")
-	fs.StringVar(&c.EnvoyImage, "envoy-image", EnvoyDefaultImage, "Envoy image with tag/version")
-	fs.StringVar(&c.PaodinMonitoringGatewayImage, "paodin-monitoring-gateway-image", PaodinMonitoringGatewayDefaultImage, "Paodin monitoring gateway image with tag/version")
-	fs.IntVar(&c.DefaultTenantsPerIngester, "defaultTenantsPerIngester", PaodinDefaultTenantsPerIngester, "Paodin default tenant count per ingester. (default 3)")
-	fs.DurationVar(&c.DefaultIngesterRetentionPeriod, "defaultIngesterRetentionPeriod", PaodinDefaultIngesterRetentionPeriod, "Paodin default ingester retention period. (default 2h)")
+	fs.StringVar(&c.WhizardImage, "whizard-image", DefaultWhizardImage, "Whizard image with tag/version")
+	fs.StringVar(&c.EnvoyImage, "envoy-image", DefaultEnvoyImage, "Envoy image with tag/version")
+	fs.StringVar(&c.GatewayImage, "gateway-image", DefaultGatewayImage, "Whizard monitoring gateway image with tag/version")
+	fs.IntVar(&c.DefaultTenantsPerIngester, "defaultTenantsPerIngester", DefaultTenantsPerIngester, "Whizard default tenant count per ingester. (default 3)")
+	fs.DurationVar(&c.DefaultIngesterRetentionPeriod, "defaultIngesterRetentionPeriod", DefaultIngesterRetentionPeriod, "Whizard default ingester retention period. (default 2h)")
 	fs.BoolVar(&c.EnableKubeSphereAdapter, "enableKubeSphereAdapter", true, "Enable KubeSphere adapter. (default true)")
-	fs.StringVar(&c.KubeSphereAdapterService, "kubeSphereAdapterService", PaodinDefaultService, "Default service for tenants generated by kubesphere adapter, format is namespace.name")
+	fs.StringVar(&c.KubeSphereAdapterService, "kubeSphereAdapterService", DefaultService, "Default service for tenants generated by kubesphere adapter, format is namespace.name")
 
 	fs.StringVar(&c.PrometheusConfigReloader.Image, "prometheus-config-reloader-image",
 		PrometheusConfigReloaderDefaultConfig.Image, "Prometheus Config Reloader image with tag/version")

--- a/pkg/controllers/monitoring/resources/base.go
+++ b/pkg/controllers/monitoring/resources/base.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	"github.com/kubesphere/paodin/pkg/util"
+	"github.com/kubesphere/whizard/pkg/util"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/controllers/monitoring/resources/common.go
+++ b/pkg/controllers/monitoring/resources/common.go
@@ -3,44 +3,9 @@ package resources
 import (
 	"strings"
 
+	"github.com/kubesphere/whizard/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-)
-
-const (
-	ThanosGRPCPort        = 10901
-	ThanosHTTPPort        = 10902
-	ThanosRemoteWritePort = 19291
-
-	ThanosGRPCPortName        = "grpc"
-	ThanosHTTPPortName        = "http"
-	ThanosRemoteWritePortName = "remote-write"
-
-	ReplicaLabelNamePrometheus    = "prometheus_replica"
-	ReplicaLabelNameThanosReceive = "thanos_receive_replica"
-	ReplicaLabelNameThanosRuler   = "thanos_ruler_replica"
-
-	AppNameGateway       = "paodin-monitoring-gateway"
-	AppNameQuery         = "query"
-	AppNameQueryFrontend = "query-frontend"
-	AppNameRouter        = "router"
-	AppNameIngester      = "ingester"
-	AppNameRuler         = "ruler"
-	AppNameStore         = "store"
-	AppNameCompactor     = "compactor"
-
-	ServiceNameSuffixOperated = "operated"
-
-	LabelNameAppComponent = "app.kubernetes.io/component"
-	LabelNameAppName      = "app.kubernetes.io/name"
-	LableNameAppInstance  = "app.kubernetes.io/instance"
-	LabelNameAppManagedBy = "app.kubernetes.io/managed-by"
-	LabelNameAppPartOf    = "app.kubernetes.io/part-of"
-
-	LabelNameIngesterState        = "monitoring.paodin.io/ingester-state"
-	LabelNameIngesterDeletingTime = "monitoring.paodin.io/ingester-deleting-time"
-
-	SecretBucketKey = "bucket.yml"
 )
 
 func QualifiedName(appName, instanceName string, suffix ...string) string {
@@ -51,7 +16,7 @@ func QualifiedName(appName, instanceName string, suffix ...string) string {
 	return name
 }
 
-func ThanosDefaultLivenessProbe() *corev1.Probe {
+func DefaultLivenessProbe() *corev1.Probe {
 	return &corev1.Probe{
 		FailureThreshold: 4,
 		PeriodSeconds:    30,
@@ -59,13 +24,13 @@ func ThanosDefaultLivenessProbe() *corev1.Probe {
 			HTTPGet: &corev1.HTTPGetAction{
 				Scheme: "HTTP",
 				Path:   "/-/healthy",
-				Port:   intstr.FromString(ThanosHTTPPortName),
+				Port:   intstr.FromString(constants.HTTPPortName),
 			},
 		},
 	}
 }
 
-func ThanosDefaultReadinessProbe() *corev1.Probe {
+func DefaultReadinessProbe() *corev1.Probe {
 	return &corev1.Probe{
 		FailureThreshold: 20,
 		PeriodSeconds:    5,
@@ -73,7 +38,7 @@ func ThanosDefaultReadinessProbe() *corev1.Probe {
 			HTTPGet: &corev1.HTTPGetAction{
 				Scheme: "HTTP",
 				Path:   "/-/ready",
-				Port:   intstr.FromString(ThanosHTTPPortName),
+				Port:   intstr.FromString(constants.HTTPPortName),
 			},
 		},
 	}

--- a/pkg/controllers/monitoring/resources/compactor/compactor.go
+++ b/pkg/controllers/monitoring/resources/compactor/compactor.go
@@ -1,9 +1,10 @@
 package compactor
 
 import (
-	"github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
-	"github.com/kubesphere/paodin/pkg/util"
+	"github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 )
@@ -22,8 +23,8 @@ func New(reconciler resources.BaseReconciler, compactor *v1alpha1.Compactor) *Co
 
 func (r *Compactor) labels() map[string]string {
 	labels := r.BaseLabels()
-	labels[resources.LabelNameAppName] = resources.AppNameCompactor
-	labels[resources.LabelNameAppManagedBy] = r.compactor.Name
+	labels[constants.LabelNameAppName] = constants.AppNameCompactor
+	labels[constants.LabelNameAppManagedBy] = r.compactor.Name
 	util.AppendLabel(labels, r.compactor.Labels)
 	return labels
 }

--- a/pkg/controllers/monitoring/resources/compactor/service.go
+++ b/pkg/controllers/monitoring/resources/compactor/service.go
@@ -1,8 +1,9 @@
 package compactor
 
 import (
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
-	"github.com/kubesphere/paodin/pkg/util"
+	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -11,7 +12,7 @@ import (
 )
 
 func (r *Compactor) service() (runtime.Object, resources.Operation, error) {
-	var s = &corev1.Service{ObjectMeta: r.meta(util.Join("-", r.compactor.Name, resources.ServiceNameSuffixOperated))}
+	var s = &corev1.Service{ObjectMeta: r.meta(util.Join("-", r.compactor.Name, constants.ServiceNameSuffix))}
 	if err := r.Client.Get(r.Context, client.ObjectKeyFromObject(s), s); err != nil {
 		if !util.IsNotFound(err) {
 			return nil, "", err
@@ -24,9 +25,9 @@ func (r *Compactor) service() (runtime.Object, resources.Operation, error) {
 	ports := []corev1.ServicePort{
 		{
 			Protocol:   corev1.ProtocolTCP,
-			Name:       resources.ThanosHTTPPortName,
-			Port:       resources.ThanosHTTPPort,
-			TargetPort: intstr.FromInt(resources.ThanosHTTPPort),
+			Name:       constants.HTTPPortName,
+			Port:       constants.HTTPPort,
+			TargetPort: intstr.FromInt(constants.HTTPPort),
 		},
 	}
 

--- a/pkg/controllers/monitoring/resources/gateway/deployment.go
+++ b/pkg/controllers/monitoring/resources/gateway/deployment.go
@@ -9,10 +9,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources/query"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources/query_frontend"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources/router"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources/query"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources/query_frontend"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources/router"
 )
 
 func (g *Gateway) deployment() (runtime.Object, resources.Operation, error) {

--- a/pkg/controllers/monitoring/resources/gateway/gateway.go
+++ b/pkg/controllers/monitoring/resources/gateway/gateway.go
@@ -1,10 +1,11 @@
 package gateway
 
 import (
+	"github.com/kubesphere/whizard/pkg/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
 )
 
 const (
@@ -25,12 +26,12 @@ func New(reconciler resources.ServiceBaseReconciler) *Gateway {
 
 func (g *Gateway) labels() map[string]string {
 	labels := g.BaseLabels()
-	labels[resources.LabelNameAppName] = resources.AppNameGateway
+	labels[constants.LabelNameAppName] = constants.AppNameGateway
 	return labels
 }
 
 func (g *Gateway) name(nameSuffix ...string) string {
-	return resources.QualifiedName(resources.AppNameGateway, g.Service.Name, nameSuffix...)
+	return resources.QualifiedName(constants.AppNameGateway, g.Service.Name, nameSuffix...)
 }
 
 func (g *Gateway) meta(name string) metav1.ObjectMeta {

--- a/pkg/controllers/monitoring/resources/gateway/service.go
+++ b/pkg/controllers/monitoring/resources/gateway/service.go
@@ -1,14 +1,15 @@
 package gateway
 
 import (
+	"github.com/kubesphere/whizard/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
 )
 
 func (g *Gateway) service() (runtime.Object, resources.Operation, error) {
-	var s = &corev1.Service{ObjectMeta: g.meta(g.name(resources.ServiceNameSuffixOperated))}
+	var s = &corev1.Service{ObjectMeta: g.meta(g.name(constants.ServiceNameSuffix))}
 
 	if g.gateway == nil {
 		return s, resources.OperationDelete, nil

--- a/pkg/controllers/monitoring/resources/ingester/ingester.go
+++ b/pkg/controllers/monitoring/resources/ingester/ingester.go
@@ -3,16 +3,15 @@ package ingester
 import (
 	"fmt"
 
+	monitoringv1alpha1 "github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-
-	monitoringv1alpha1 "github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
 )
 
 const (
-	secretsDir = "/etc/thanos/secrets"
-	storageDir = "/thanos"
+	storageDir = "/whizard"
 )
 
 type Ingester struct {
@@ -29,13 +28,13 @@ func New(reconciler resources.BaseReconciler, ingester *monitoringv1alpha1.Inges
 
 func (r *Ingester) labels() map[string]string {
 	labels := r.BaseLabels()
-	labels[resources.LabelNameAppName] = resources.AppNameIngester
-	labels[resources.LabelNameAppManagedBy] = r.ingester.Name
+	labels[constants.LabelNameAppName] = constants.AppNameIngester
+	labels[constants.LabelNameAppManagedBy] = r.ingester.Name
 	return labels
 }
 
 func (r *Ingester) name(nameSuffix ...string) string {
-	return resources.QualifiedName(resources.AppNameIngester, r.ingester.Name, nameSuffix...)
+	return resources.QualifiedName(constants.AppNameIngester, r.ingester.Name, nameSuffix...)
 }
 
 func (r *Ingester) meta(name string) metav1.ObjectMeta {
@@ -69,7 +68,7 @@ func (r *Ingester) GrpcAddrs() []string {
 	}
 	for i := range addrs {
 		addrs[i] = fmt.Sprintf("%s-%d.%s.%s.svc:%d",
-			r.name(), i, r.name(resources.ServiceNameSuffixOperated), r.ingester.Namespace, resources.ThanosGRPCPort)
+			r.name(), i, r.name(constants.ServiceNameSuffix), r.ingester.Namespace, constants.GRPCPort)
 	}
 	return addrs
 }

--- a/pkg/controllers/monitoring/resources/ingester/service.go
+++ b/pkg/controllers/monitoring/resources/ingester/service.go
@@ -1,14 +1,15 @@
 package ingester
 
 import (
+	"github.com/kubesphere/whizard/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
 )
 
 func (r *Ingester) service() (runtime.Object, resources.Operation, error) {
-	var s = &corev1.Service{ObjectMeta: r.meta(r.name(resources.ServiceNameSuffixOperated))}
+	var s = &corev1.Service{ObjectMeta: r.meta(r.name(constants.ServiceNameSuffix))}
 
 	s.Spec = corev1.ServiceSpec{
 		ClusterIP: corev1.ClusterIPNone,
@@ -16,18 +17,18 @@ func (r *Ingester) service() (runtime.Object, resources.Operation, error) {
 		Ports: []corev1.ServicePort{
 			{
 				Protocol: corev1.ProtocolTCP,
-				Name:     resources.ThanosGRPCPortName,
-				Port:     resources.ThanosGRPCPort,
+				Name:     constants.GRPCPortName,
+				Port:     constants.GRPCPort,
 			},
 			{
 				Protocol: corev1.ProtocolTCP,
-				Name:     resources.ThanosHTTPPortName,
-				Port:     resources.ThanosHTTPPort,
+				Name:     constants.HTTPPortName,
+				Port:     constants.HTTPPort,
 			},
 			{
 				Protocol: corev1.ProtocolTCP,
-				Name:     resources.ThanosRemoteWritePortName,
-				Port:     resources.ThanosRemoteWritePort,
+				Name:     constants.RemoteWritePortName,
+				Port:     constants.RemoteWritePort,
 			},
 		},
 	}

--- a/pkg/controllers/monitoring/resources/query/configmap.go
+++ b/pkg/controllers/monitoring/resources/query/configmap.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
 )
 
 func (q *Query) proxyConfigMap() (runtime.Object, resources.Operation, error) {

--- a/pkg/controllers/monitoring/resources/query/deployment.go
+++ b/pkg/controllers/monitoring/resources/query/deployment.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"path/filepath"
 
-	monitoringv1alpha1 "github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources/ingester"
-	"github.com/kubesphere/paodin/pkg/util"
+	monitoringv1alpha1 "github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources/ingester"
+	"github.com/kubesphere/whizard/pkg/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -70,17 +71,17 @@ func (q *Query) deployment() (runtime.Object, resources.Operation, error) {
 		Ports: []corev1.ContainerPort{
 			{
 				Protocol:      corev1.ProtocolTCP,
-				Name:          resources.ThanosGRPCPortName,
-				ContainerPort: resources.ThanosGRPCPort,
+				Name:          constants.GRPCPortName,
+				ContainerPort: constants.GRPCPort,
 			},
 			{
 				Protocol:      corev1.ProtocolTCP,
-				Name:          resources.ThanosHTTPPortName,
-				ContainerPort: resources.ThanosHTTPPort,
+				Name:          constants.HTTPPortName,
+				ContainerPort: constants.HTTPPort,
 			},
 		},
-		LivenessProbe:  resources.ThanosDefaultLivenessProbe(),
-		ReadinessProbe: resources.ThanosDefaultReadinessProbe(),
+		LivenessProbe:  resources.DefaultLivenessProbe(),
+		ReadinessProbe: resources.DefaultReadinessProbe(),
 		VolumeMounts: []corev1.VolumeMount{{
 			Name:      storesConfigVol.Name,
 			MountPath: configDir,
@@ -121,8 +122,8 @@ func (q *Query) deployment() (runtime.Object, resources.Operation, error) {
 		return nil, resources.OperationCreateOrUpdate, err
 	}
 	for _, item := range storeList.Items {
-		storeSvcName := util.Join("-", item.Name, resources.ServiceNameSuffixOperated)
-		endpoint := fmt.Sprintf("%s.%s.svc:%d", storeSvcName, item.Namespace, resources.ThanosGRPCPort)
+		storeSvcName := util.Join("-", item.Name, constants.ServiceNameSuffix)
+		endpoint := fmt.Sprintf("%s.%s.svc:%d", storeSvcName, item.Namespace, constants.GRPCPort)
 		queryContainer.Args = append(queryContainer.Args, "--endpoint="+endpoint)
 	}
 
@@ -134,8 +135,8 @@ func (q *Query) deployment() (runtime.Object, resources.Operation, error) {
 		return nil, resources.OperationCreateOrUpdate, err
 	}
 	for _, item := range rulerList.Items {
-		rulerSvcName := resources.QualifiedName(resources.AppNameRuler, item.Name, resources.ServiceNameSuffixOperated)
-		endpoint := fmt.Sprintf("%s.%s.svc:%d", rulerSvcName, item.Namespace, resources.ThanosGRPCPort)
+		rulerSvcName := resources.QualifiedName(constants.AppNameRuler, item.Name, constants.ServiceNameSuffix)
+		endpoint := fmt.Sprintf("%s.%s.svc:%d", rulerSvcName, item.Namespace, constants.GRPCPort)
 		queryContainer.Args = append(queryContainer.Args, "--endpoint="+endpoint)
 	}
 

--- a/pkg/controllers/monitoring/resources/query/query.go
+++ b/pkg/controllers/monitoring/resources/query/query.go
@@ -6,14 +6,14 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
 )
 
 const (
-	configDir  = "/etc/thanos"
+	configDir  = "/etc/whizard"
 	storesFile = "store-sd.yaml"
 )
 
@@ -80,13 +80,13 @@ func (q *Query) stores() (*Stores, error) {
 
 func (q *Query) labels() map[string]string {
 	labels := q.BaseLabels()
-	labels[resources.LabelNameAppName] = resources.AppNameQuery
-	labels[resources.LabelNameAppManagedBy] = q.Service.Name
+	labels[constants.LabelNameAppName] = constants.AppNameQuery
+	labels[constants.LabelNameAppManagedBy] = q.Service.Name
 	return labels
 }
 
 func (q *Query) name(nameSuffix ...string) string {
-	return resources.QualifiedName(resources.AppNameQuery, q.Service.Name, nameSuffix...)
+	return resources.QualifiedName(constants.AppNameQuery, q.Service.Name, nameSuffix...)
 }
 
 func (q *Query) meta(name string) metav1.ObjectMeta {
@@ -101,7 +101,7 @@ func (q *Query) meta(name string) metav1.ObjectMeta {
 
 func (q *Query) HttpAddr() string {
 	return fmt.Sprintf("http://%s.%s.svc:%d",
-		q.name(resources.ServiceNameSuffixOperated), q.Service.Namespace, resources.ThanosHTTPPort)
+		q.name(constants.ServiceNameSuffix), q.Service.Namespace, constants.HTTPPort)
 }
 
 func (q *Query) Reconcile() error {

--- a/pkg/controllers/monitoring/resources/query/service.go
+++ b/pkg/controllers/monitoring/resources/query/service.go
@@ -1,14 +1,15 @@
 package query
 
 import (
+	"github.com/kubesphere/whizard/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
 )
 
 func (q *Query) service() (runtime.Object, resources.Operation, error) {
-	var s = &corev1.Service{ObjectMeta: q.meta(q.name(resources.ServiceNameSuffixOperated))}
+	var s = &corev1.Service{ObjectMeta: q.meta(q.name(constants.ServiceNameSuffix))}
 
 	if q.query == nil {
 		return s, resources.OperationDelete, nil
@@ -19,13 +20,13 @@ func (q *Query) service() (runtime.Object, resources.Operation, error) {
 		Ports: []corev1.ServicePort{
 			{
 				Protocol: corev1.ProtocolTCP,
-				Name:     resources.ThanosGRPCPortName,
-				Port:     resources.ThanosGRPCPort,
+				Name:     constants.GRPCPortName,
+				Port:     constants.GRPCPort,
 			},
 			{
 				Protocol: corev1.ProtocolTCP,
-				Name:     resources.ThanosHTTPPortName,
-				Port:     resources.ThanosHTTPPort,
+				Name:     constants.HTTPPortName,
+				Port:     constants.HTTPPort,
 			},
 		},
 	}

--- a/pkg/controllers/monitoring/resources/query_frontend/configmap.go
+++ b/pkg/controllers/monitoring/resources/query_frontend/configmap.go
@@ -3,8 +3,8 @@ package query_frontend
 import (
 	"time"
 
-	"github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
 
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/controllers/monitoring/resources/query_frontend/deployment.go
+++ b/pkg/controllers/monitoring/resources/query_frontend/deployment.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources/query"
+	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources/query"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -56,12 +57,12 @@ func (q *QueryFrontend) deployment() (runtime.Object, resources.Operation, error
 		Ports: []corev1.ContainerPort{
 			{
 				Protocol:      corev1.ProtocolTCP,
-				Name:          resources.ThanosHTTPPortName,
-				ContainerPort: resources.ThanosHTTPPort,
+				Name:          constants.HTTPPortName,
+				ContainerPort: constants.HTTPPort,
 			},
 		},
-		LivenessProbe:  resources.ThanosDefaultLivenessProbe(),
-		ReadinessProbe: resources.ThanosDefaultReadinessProbe(),
+		LivenessProbe:  resources.DefaultLivenessProbe(),
+		ReadinessProbe: resources.DefaultReadinessProbe(),
 		VolumeMounts: []corev1.VolumeMount{{
 			Name:      cacheConfigVol.Name,
 			MountPath: configDir,

--- a/pkg/controllers/monitoring/resources/query_frontend/query_frontend.go
+++ b/pkg/controllers/monitoring/resources/query_frontend/query_frontend.go
@@ -3,13 +3,14 @@ package query_frontend
 import (
 	"fmt"
 
-	monitoringv1alpha1 "github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
+	monitoringv1alpha1 "github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
-	configDir       = "/etc/thanos"
+	configDir       = "/etc/whizard"
 	cacheConfigFile = "cache-config.yaml"
 )
 
@@ -27,13 +28,13 @@ func New(reconciler resources.ServiceBaseReconciler) *QueryFrontend {
 
 func (q *QueryFrontend) labels() map[string]string {
 	labels := q.BaseLabels()
-	labels[resources.LabelNameAppName] = resources.AppNameQueryFrontend
-	labels[resources.LabelNameAppManagedBy] = q.Service.Name
+	labels[constants.LabelNameAppName] = constants.AppNameQueryFrontend
+	labels[constants.LabelNameAppManagedBy] = q.Service.Name
 	return labels
 }
 
 func (q *QueryFrontend) name(nameSuffix ...string) string {
-	return resources.QualifiedName(resources.AppNameQueryFrontend, q.Service.Name, nameSuffix...)
+	return resources.QualifiedName(constants.AppNameQueryFrontend, q.Service.Name, nameSuffix...)
 }
 
 func (q *QueryFrontend) meta(name string) metav1.ObjectMeta {
@@ -48,7 +49,7 @@ func (q *QueryFrontend) meta(name string) metav1.ObjectMeta {
 
 func (q *QueryFrontend) HttpAddr() string {
 	return fmt.Sprintf("http://%s.%s.svc:%d",
-		q.name(resources.ServiceNameSuffixOperated), q.Service.Namespace, resources.ThanosHTTPPort)
+		q.name(constants.ServiceNameSuffix), q.Service.Namespace, constants.HTTPPort)
 }
 
 func (q *QueryFrontend) Reconcile() error {

--- a/pkg/controllers/monitoring/resources/query_frontend/service.go
+++ b/pkg/controllers/monitoring/resources/query_frontend/service.go
@@ -1,14 +1,14 @@
 package query_frontend
 
 import (
+	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
 )
 
 func (q *QueryFrontend) service() (runtime.Object, resources.Operation, error) {
-	var s = &corev1.Service{ObjectMeta: q.meta(q.name(resources.ServiceNameSuffixOperated))}
+	var s = &corev1.Service{ObjectMeta: q.meta(q.name(constants.ServiceNameSuffix))}
 
 	if q.queryFrontend == nil {
 		return s, resources.OperationDelete, nil
@@ -20,8 +20,8 @@ func (q *QueryFrontend) service() (runtime.Object, resources.Operation, error) {
 		Ports: []corev1.ServicePort{
 			{
 				Protocol: corev1.ProtocolTCP,
-				Name:     resources.ThanosHTTPPortName,
-				Port:     resources.ThanosHTTPPort,
+				Name:     constants.HTTPPortName,
+				Port:     constants.HTTPPort,
 			},
 		},
 	}

--- a/pkg/controllers/monitoring/resources/router/configmap.go
+++ b/pkg/controllers/monitoring/resources/router/configmap.go
@@ -7,9 +7,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	monitoringv1alpha1 "github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources/ingester"
+	monitoringv1alpha1 "github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources/ingester"
 )
 
 func (r *Router) hashringsConfigMap() (runtime.Object, resources.Operation, error) {

--- a/pkg/controllers/monitoring/resources/router/router.go
+++ b/pkg/controllers/monitoring/resources/router/router.go
@@ -3,14 +3,14 @@ package router
 import (
 	"fmt"
 
+	"github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
 )
 
 const (
-	configDir     = "/etc/thanos"
+	configDir     = "/etc/whizard"
 	hashringsFile = "hashrings.json"
 )
 
@@ -28,13 +28,13 @@ func New(reconciler resources.ServiceBaseReconciler) *Router {
 
 func (r *Router) labels() map[string]string {
 	labels := r.BaseLabels()
-	labels[resources.LabelNameAppName] = resources.AppNameRouter
-	labels[resources.LabelNameAppManagedBy] = r.Service.Name
+	labels[constants.LabelNameAppName] = constants.AppNameRouter
+	labels[constants.LabelNameAppManagedBy] = r.Service.Name
 	return labels
 }
 
 func (r *Router) name(nameSuffix ...string) string {
-	return resources.QualifiedName(resources.AppNameRouter, r.Service.Name, nameSuffix...)
+	return resources.QualifiedName(constants.AppNameRouter, r.Service.Name, nameSuffix...)
 }
 
 func (r *Router) meta(name string) metav1.ObjectMeta {
@@ -49,12 +49,12 @@ func (r *Router) meta(name string) metav1.ObjectMeta {
 
 func (r *Router) HttpAddr() string {
 	return fmt.Sprintf("http://%s.%s.svc:%d",
-		r.name(resources.ServiceNameSuffixOperated), r.Service.Namespace, resources.ThanosHTTPPort)
+		r.name(constants.ServiceNameSuffix), r.Service.Namespace, constants.HTTPPort)
 }
 
 func (r *Router) RemoteWriteAddr() string {
 	return fmt.Sprintf("http://%s.%s.svc:%d",
-		r.name(resources.ServiceNameSuffixOperated), r.Service.Namespace, resources.ThanosRemoteWritePort)
+		r.name(constants.ServiceNameSuffix), r.Service.Namespace, constants.RemoteWritePort)
 }
 
 func (r *Router) Reconcile() error {

--- a/pkg/controllers/monitoring/resources/router/service.go
+++ b/pkg/controllers/monitoring/resources/router/service.go
@@ -1,14 +1,14 @@
 package router
 
 import (
+	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
 )
 
 func (r *Router) service() (runtime.Object, resources.Operation, error) {
-	var s = &corev1.Service{ObjectMeta: r.meta(r.name(resources.ServiceNameSuffixOperated))}
+	var s = &corev1.Service{ObjectMeta: r.meta(r.name(constants.ServiceNameSuffix))}
 
 	if r.router == nil {
 		return s, resources.OperationDelete, nil
@@ -20,18 +20,18 @@ func (r *Router) service() (runtime.Object, resources.Operation, error) {
 		Ports: []corev1.ServicePort{
 			{
 				Protocol: corev1.ProtocolTCP,
-				Name:     resources.ThanosGRPCPortName,
-				Port:     resources.ThanosGRPCPort,
+				Name:     constants.GRPCPortName,
+				Port:     constants.GRPCPort,
 			},
 			{
 				Protocol: corev1.ProtocolTCP,
-				Name:     resources.ThanosHTTPPortName,
-				Port:     resources.ThanosHTTPPort,
+				Name:     constants.HTTPPortName,
+				Port:     constants.HTTPPort,
 			},
 			{
 				Protocol: corev1.ProtocolTCP,
-				Name:     resources.ThanosRemoteWritePortName,
-				Port:     resources.ThanosRemoteWritePort,
+				Name:     constants.RemoteWritePortName,
+				Port:     constants.RemoteWritePort,
 			},
 		},
 	}

--- a/pkg/controllers/monitoring/resources/ruler/configmap.go
+++ b/pkg/controllers/monitoring/resources/ruler/configmap.go
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	monitoringv1alpha1 "github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
+	monitoringv1alpha1 "github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
 )
 
 var maxConfigMapDataSize = int(float64(corev1.MaxSecretSize) * 0.5)

--- a/pkg/controllers/monitoring/resources/ruler/ruler.go
+++ b/pkg/controllers/monitoring/resources/ruler/ruler.go
@@ -3,20 +3,20 @@ package ruler
 import (
 	"fmt"
 
+	"github.com/kubesphere/whizard/pkg/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 
-	monitoringv1alpha1 "github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/options"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
+	monitoringv1alpha1 "github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/options"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
 )
 
 const (
-	configDir       = "/etc/thanos"
-	rulesDir        = configDir + "/rules"
-	storageDir      = "/thanos"
-	remoteWriteFile = "remote-write.yaml"
+	configDir  = "/etc/whizard"
+	rulesDir   = configDir + "/rules"
+	storageDir = "/whizard"
 )
 
 type Ruler struct {
@@ -39,13 +39,13 @@ func New(reconciler resources.BaseReconciler, ruler *monitoringv1alpha1.Ruler,
 
 func (r *Ruler) labels() map[string]string {
 	labels := r.BaseLabels()
-	labels[resources.LabelNameAppName] = resources.AppNameRuler
-	labels[resources.LabelNameAppManagedBy] = r.ruler.Name
+	labels[constants.LabelNameAppName] = constants.AppNameRuler
+	labels[constants.LabelNameAppManagedBy] = r.ruler.Name
 	return labels
 }
 
 func (r *Ruler) name(nameSuffix ...string) string {
-	return resources.QualifiedName(resources.AppNameRuler, r.ruler.Name, nameSuffix...)
+	return resources.QualifiedName(constants.AppNameRuler, r.ruler.Name, nameSuffix...)
 }
 
 func (r *Ruler) meta(name string) metav1.ObjectMeta {
@@ -72,7 +72,7 @@ func (r *Ruler) OwnerReferences() []metav1.OwnerReference {
 
 func (r *Ruler) HttpAddr() string {
 	return fmt.Sprintf("http://%s.%s.svc:%d",
-		r.name(resources.ServiceNameSuffixOperated), r.ruler.Namespace, resources.ThanosHTTPPort)
+		r.name(constants.ServiceNameSuffix), r.ruler.Namespace, constants.HTTPPort)
 }
 
 func (r *Ruler) Reconcile() error {

--- a/pkg/controllers/monitoring/resources/ruler/service.go
+++ b/pkg/controllers/monitoring/resources/ruler/service.go
@@ -1,14 +1,14 @@
 package ruler
 
 import (
+	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
 )
 
 func (r *Ruler) service() (runtime.Object, resources.Operation, error) {
-	var s = &corev1.Service{ObjectMeta: r.meta(r.name(resources.ServiceNameSuffixOperated))}
+	var s = &corev1.Service{ObjectMeta: r.meta(r.name(constants.ServiceNameSuffix))}
 
 	if r.ruler == nil {
 		return s, resources.OperationDelete, nil
@@ -20,13 +20,13 @@ func (r *Ruler) service() (runtime.Object, resources.Operation, error) {
 		Ports: []corev1.ServicePort{
 			{
 				Protocol: corev1.ProtocolTCP,
-				Name:     resources.ThanosGRPCPortName,
-				Port:     resources.ThanosGRPCPort,
+				Name:     constants.GRPCPortName,
+				Port:     constants.GRPCPort,
 			},
 			{
 				Protocol: corev1.ProtocolTCP,
-				Name:     resources.ThanosHTTPPortName,
-				Port:     resources.ThanosHTTPPort,
+				Name:     constants.HTTPPortName,
+				Port:     constants.HTTPPort,
 			},
 		},
 	}

--- a/pkg/controllers/monitoring/resources/service.go
+++ b/pkg/controllers/monitoring/resources/service.go
@@ -1,10 +1,10 @@
 package resources
 
 import (
+	"github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-
-	"github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
 )
 
 type ServiceBaseReconciler struct {
@@ -15,8 +15,8 @@ type ServiceBaseReconciler struct {
 
 func (r *ServiceBaseReconciler) BaseLabels() map[string]string {
 	return map[string]string{
-		LabelNameAppManagedBy: r.Service.Name,
-		LabelNameAppPartOf:    "service",
+		constants.LabelNameAppManagedBy: r.Service.Name,
+		constants.LabelNameAppPartOf:    "service",
 	}
 }
 

--- a/pkg/controllers/monitoring/resources/storage/secret.go
+++ b/pkg/controllers/monitoring/resources/storage/secret.go
@@ -9,10 +9,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
 )
 
-var LabelNameStorageHash = "monitoring.paodin.io/storage-hash"
+var LabelNameStorageHash = "monitoring.whizard.io/storage-hash"
 
 // updateHashAnnotation generate the hash with objstoreConfig to write to the annotation. When the secret update hash changes, the storage update event is triggered.
 func (s *Storage) updateHashAnnotation() (runtime.Object, resources.Operation, error) {

--- a/pkg/controllers/monitoring/resources/storage/storage.go
+++ b/pkg/controllers/monitoring/resources/storage/storage.go
@@ -1,8 +1,8 @@
 package storage
 
 import (
-	monitoringv1alpha1 "github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
+	monitoringv1alpha1 "github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
 )
 
 type Storage struct {

--- a/pkg/controllers/monitoring/resources/store.go
+++ b/pkg/controllers/monitoring/resources/store.go
@@ -1,10 +1,10 @@
 package resources
 
 import (
+	"github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-
-	"github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
 )
 
 type StoreBaseReconciler struct {
@@ -15,8 +15,8 @@ type StoreBaseReconciler struct {
 
 func (r *StoreBaseReconciler) BaseLabels() map[string]string {
 	return map[string]string{
-		LabelNameAppManagedBy: r.Store.Name,
-		LabelNameAppPartOf:    "store",
+		constants.LabelNameAppManagedBy: r.Store.Name,
+		constants.LabelNameAppPartOf:    "store",
 	}
 }
 

--- a/pkg/controllers/monitoring/resources/store/hpa.go
+++ b/pkg/controllers/monitoring/resources/store/hpa.go
@@ -1,8 +1,8 @@
 package store
 
 import (
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
-	"github.com/kubesphere/paodin/pkg/util"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/util"
 	"k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/controllers/monitoring/resources/store/service.go
+++ b/pkg/controllers/monitoring/resources/store/service.go
@@ -1,8 +1,9 @@
 package store
 
 import (
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
-	"github.com/kubesphere/paodin/pkg/util"
+	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -11,7 +12,7 @@ import (
 )
 
 func (r *Store) service() (runtime.Object, resources.Operation, error) {
-	var s = &corev1.Service{ObjectMeta: r.meta(util.Join("-", r.store.Name, resources.ServiceNameSuffixOperated))}
+	var s = &corev1.Service{ObjectMeta: r.meta(util.Join("-", r.store.Name, constants.ServiceNameSuffix))}
 
 	if err := r.Client.Get(r.Context, client.ObjectKeyFromObject(s), s); err != nil {
 		if !util.IsNotFound(err) {
@@ -25,15 +26,15 @@ func (r *Store) service() (runtime.Object, resources.Operation, error) {
 	ports := []corev1.ServicePort{
 		{
 			Protocol:   corev1.ProtocolTCP,
-			Name:       resources.ThanosGRPCPortName,
-			Port:       resources.ThanosGRPCPort,
-			TargetPort: intstr.FromInt(resources.ThanosGRPCPort),
+			Name:       constants.GRPCPortName,
+			Port:       constants.GRPCPort,
+			TargetPort: intstr.FromInt(constants.GRPCPort),
 		},
 		{
 			Protocol:   corev1.ProtocolTCP,
-			Name:       resources.ThanosHTTPPortName,
-			Port:       resources.ThanosHTTPPort,
-			TargetPort: intstr.FromInt(resources.ThanosHTTPPort),
+			Name:       constants.HTTPPortName,
+			Port:       constants.HTTPPort,
+			TargetPort: intstr.FromInt(constants.HTTPPort),
 		},
 	}
 

--- a/pkg/controllers/monitoring/resources/store/store.go
+++ b/pkg/controllers/monitoring/resources/store/store.go
@@ -1,10 +1,11 @@
 package store
 
 import (
-	"github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/options"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
-	"github.com/kubesphere/paodin/pkg/util"
+	"github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/options"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 )
@@ -25,8 +26,8 @@ func New(reconciler resources.BaseReconciler, instance *v1alpha1.Store, o option
 
 func (r *Store) labels() map[string]string {
 	labels := r.BaseLabels()
-	labels[resources.LabelNameAppName] = resources.AppNameStore
-	labels[resources.LabelNameAppManagedBy] = r.store.Name
+	labels[constants.LabelNameAppName] = constants.AppNameStore
+	labels[constants.LabelNameAppManagedBy] = r.store.Name
 	util.AppendLabel(labels, r.store.Labels)
 	return labels
 }

--- a/pkg/controllers/monitoring/resources/tenant/ingestor.go
+++ b/pkg/controllers/monitoring/resources/tenant/ingestor.go
@@ -7,28 +7,27 @@ import (
 	"strings"
 	"time"
 
+	monitoringv1alpha1 "github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/util"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	monitoringv1alpha1 "github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
-	"github.com/kubesphere/paodin/pkg/util"
 )
 
 func (t *Tenant) ingester() error {
 
 	// finalizers check,  when tenant cr is deleted, ObjectMeta.GetDeletionTimestamp() is not nil, remove finalizers field and call removeTenantFromIngesterbyName()
 	if t.tenant.ObjectMeta.GetDeletionTimestamp().IsZero() {
-		if !containsString(t.tenant.ObjectMeta.Finalizers, monitoringv1alpha1.FinalizerMonitoringIngester) {
-			t.tenant.ObjectMeta.Finalizers = append(t.tenant.ObjectMeta.Finalizers, monitoringv1alpha1.FinalizerMonitoringIngester)
+		if !containsString(t.tenant.ObjectMeta.Finalizers, constants.FinalizerIngester) {
+			t.tenant.ObjectMeta.Finalizers = append(t.tenant.ObjectMeta.Finalizers, constants.FinalizerIngester)
 			return t.Client.Update(t.Context, t.tenant)
 		}
 	} else {
-		if containsString(t.tenant.ObjectMeta.Finalizers, monitoringv1alpha1.FinalizerMonitoringIngester) {
+		if containsString(t.tenant.ObjectMeta.Finalizers, constants.FinalizerIngester) {
 			if t.tenant.Status.Ingester != nil {
 				if err := t.removeTenantFromIngesterbyName(t.tenant.Status.Ingester.Namespace, t.tenant.Status.Ingester.Name); err != nil {
 					return err
@@ -36,7 +35,7 @@ func (t *Tenant) ingester() error {
 				t.tenant.Status.Ingester = nil
 			}
 
-			t.tenant.ObjectMeta.Finalizers = removeString(t.tenant.Finalizers, monitoringv1alpha1.FinalizerMonitoringIngester)
+			t.tenant.ObjectMeta.Finalizers = removeString(t.tenant.Finalizers, constants.FinalizerIngester)
 			return t.Client.Update(t.Context, t.tenant)
 		}
 	}
@@ -61,12 +60,12 @@ func (t *Tenant) ingester() error {
 				needResetIngester = true
 			}
 
-			if v, ok := ingester.Labels[monitoringv1alpha1.MonitoringPaodinService]; !ok || v != t.tenant.Labels[monitoringv1alpha1.MonitoringPaodinService] {
+			if v, ok := ingester.Labels[constants.ServiceLabelKey]; !ok || v != t.tenant.Labels[constants.ServiceLabelKey] {
 				klog.V(3).Infof("Tenant [%s] and ingester [%s]'s Service mismatch, need to reset ingester", t.tenant.Name, ingester.Name)
 				needResetIngester = true
 			}
 
-			if v, ok := ingester.Labels[monitoringv1alpha1.MonitoringPaodinStorage]; !ok || v != t.tenant.Labels[monitoringv1alpha1.MonitoringPaodinStorage] {
+			if v, ok := ingester.Labels[constants.StorageLabelKey]; !ok || v != t.tenant.Labels[constants.TenantLabelKey] {
 				klog.V(3).Infof("Tenant [%s] and ingester [%s]'s Storage mismatch, need to reset ingester", t.tenant.Name, ingester.Name)
 				needResetIngester = true
 			}
@@ -86,7 +85,7 @@ func (t *Tenant) ingester() error {
 	}
 
 	// when tenant.Labels don't contain Service, remove the bindings to ingester and ruler
-	if v, ok := t.tenant.Labels[monitoringv1alpha1.MonitoringPaodinService]; !ok || v == "" {
+	if v, ok := t.tenant.Labels[constants.ServiceLabelKey]; !ok || v == "" {
 		klog.V(3).Infof("Tenant [%s]'s Service is empty. ingester does not need to be created", t.tenant.Name)
 		if t.tenant.Status.Ingester != nil {
 			err := t.removeTenantFromIngesterbyName(t.tenant.Status.Ingester.Namespace, t.tenant.Status.Ingester.Name)
@@ -100,9 +99,9 @@ func (t *Tenant) ingester() error {
 
 	var ingesterList monitoringv1alpha1.IngesterList
 	ls := make(map[string]string, 2)
-	ls[monitoringv1alpha1.MonitoringPaodinService] = t.tenant.Labels[monitoringv1alpha1.MonitoringPaodinService]
-	ls[monitoringv1alpha1.MonitoringPaodinStorage] = t.tenant.Labels[monitoringv1alpha1.MonitoringPaodinStorage]
-	serviceNamespacedName := strings.Split(t.tenant.Labels[monitoringv1alpha1.MonitoringPaodinService], ".")
+	ls[constants.ServiceLabelKey] = t.tenant.Labels[constants.ServiceLabelKey]
+	ls[constants.StorageLabelKey] = t.tenant.Labels[constants.StorageLabelKey]
+	serviceNamespacedName := strings.Split(t.tenant.Labels[constants.ServiceLabelKey], ".")
 	err := t.Client.List(t.Context, &ingesterList, &client.ListOptions{
 		Namespace:     serviceNamespacedName[0],
 		LabelSelector: labels.SelectorFromSet(ls),
@@ -177,15 +176,15 @@ func (t *Tenant) removeTenantFromIngesterbyName(namespace, name string) error {
 		if ok := containsString(ingester.Spec.Tenants, t.tenant.Spec.Tenant); ok {
 			klog.V(3).Infof("ingester %s update, remove tenant %s", ingester.Name, t.tenant.Name)
 			ingester.Spec.Tenants = removeString(ingester.Spec.Tenants, t.tenant.Spec.Tenant)
-			ingester.Labels[monitoringv1alpha1.MonitoringPaodinTenant] = strings.Join(ingester.Spec.Tenants, "_")
+			ingester.Labels[constants.TenantLabelKey] = strings.Join(ingester.Spec.Tenants, "_")
 
 			if len(ingester.Spec.Tenants) == 0 {
 				annotation := ingester.GetAnnotations()
 				if annotation == nil {
 					annotation = make(map[string]string)
 				}
-				annotation[resources.LabelNameIngesterState] = "deleting"
-				annotation[resources.LabelNameIngesterDeletingTime] = strconv.Itoa(int(time.Now().Add(t.Options.DefaultIngesterRetentionPeriod).Unix()))
+				annotation[constants.LabelNameIngesterState] = "deleting"
+				annotation[constants.LabelNameIngesterDeletingTime] = strconv.Itoa(int(time.Now().Add(t.Options.DefaultIngesterRetentionPeriod).Unix()))
 				ingester.Annotations = annotation
 			}
 
@@ -215,8 +214,8 @@ func (t *Tenant) deleteIngesterInstance(namespace, name string) error {
 
 	annotations := ingester.GetAnnotations()
 	if annotations != nil {
-		if v, ok := annotations[resources.LabelNameIngesterState]; ok && v == "deleting" {
-			if v, ok := annotations[monitoringv1alpha1.MonitoringPaodinTenant]; !ok || len(v) == 0 {
+		if v, ok := annotations[constants.LabelNameIngesterState]; ok && v == "deleting" {
+			if v, ok := annotations[constants.TenantLabelKey]; !ok || len(v) == 0 {
 				klog.V(3).Infof("Ingester %s will be deleted.")
 				t.Client.Delete(t.Context, ingester)
 			}
@@ -260,8 +259,8 @@ func (t *Tenant) isStorageContainLabel(namespace, name string, matchLabels map[s
 }
 
 func createIngesterInstanceName(tenant *monitoringv1alpha1.Tenant, suffix ...string) string {
-	serviceNamespacedName := strings.Split(tenant.Labels[monitoringv1alpha1.MonitoringPaodinService], ".")
-	storageNamespacedName := strings.Split(tenant.Labels[monitoringv1alpha1.MonitoringPaodinStorage], ".")
+	serviceNamespacedName := strings.Split(tenant.Labels[constants.ServiceLabelKey], ".")
+	storageNamespacedName := strings.Split(tenant.Labels[constants.StorageLabelKey], ".")
 
 	name := fmt.Sprintf("%s-%s-auto", serviceNamespacedName[1], storageNamespacedName[1])
 	if len(suffix) > 0 {
@@ -273,11 +272,11 @@ func createIngesterInstanceName(tenant *monitoringv1alpha1.Tenant, suffix ...str
 func createIngesterInstance(name string, tenant *monitoringv1alpha1.Tenant) *monitoringv1alpha1.Ingester {
 	klog.V(3).Infof("create new ingester %s for tenant %s", name, tenant.Name)
 	label := make(map[string]string, 2)
-	label[monitoringv1alpha1.MonitoringPaodinService] = tenant.Labels[monitoringv1alpha1.MonitoringPaodinService]
-	label[monitoringv1alpha1.MonitoringPaodinStorage] = tenant.Labels[monitoringv1alpha1.MonitoringPaodinStorage]
-	label[monitoringv1alpha1.MonitoringPaodinTenant] = tenant.Name
+	label[constants.ServiceLabelKey] = tenant.Labels[constants.ServiceLabelKey]
+	label[constants.StorageLabelKey] = tenant.Labels[constants.StorageLabelKey]
+	label[constants.TenantLabelKey] = tenant.Name
 
-	namespacedName := strings.Split(tenant.Labels[monitoringv1alpha1.MonitoringPaodinService], ".")
+	namespacedName := strings.Split(tenant.Labels[constants.ServiceLabelKey], ".")
 	// todo: ingester config
 	return &monitoringv1alpha1.Ingester{
 		ObjectMeta: metav1.ObjectMeta{
@@ -297,17 +296,17 @@ func addTenantToIngesterInstance(tenant *monitoringv1alpha1.Tenant, ingester *mo
 	ingester.Spec.Tenants = append(ingester.Spec.Tenants, tenant.Spec.Tenant)
 
 	label := ingester.GetLabels()
-	if v, ok := label[monitoringv1alpha1.MonitoringPaodinTenant]; !ok || len(v) == 0 {
-		label[monitoringv1alpha1.MonitoringPaodinTenant] = tenant.Name
+	if v, ok := label[constants.TenantLabelKey]; !ok || len(v) == 0 {
+		label[constants.TenantLabelKey] = tenant.Name
 	} else {
-		label[monitoringv1alpha1.MonitoringPaodinTenant] = label[monitoringv1alpha1.MonitoringPaodinTenant] + "." + tenant.Name
+		label[constants.TenantLabelKey] = label[constants.TenantLabelKey] + "." + tenant.Name
 	}
 	ingester.Labels = label
 
 	annotation := ingester.GetAnnotations()
-	if v, ok := annotation[resources.LabelNameIngesterState]; ok && v == "deleting" {
-		annotation[resources.LabelNameIngesterState] = "running"
-		annotation[resources.LabelNameIngesterDeletingTime] = ""
+	if v, ok := annotation[constants.LabelNameIngesterState]; ok && v == "deleting" {
+		annotation[constants.LabelNameIngesterState] = "running"
+		annotation[constants.LabelNameIngesterDeletingTime] = ""
 	}
 	ingester.Annotations = annotation
 }

--- a/pkg/controllers/monitoring/resources/tenant/store.go
+++ b/pkg/controllers/monitoring/resources/tenant/store.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	monitoringv1alpha1 "github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
+	monitoringv1alpha1 "github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
@@ -29,13 +30,13 @@ func (t *Tenant) store() error {
 			continue
 		}
 
-		serviceNamespacedName := store.Labels[monitoringv1alpha1.MonitoringPaodinService]
+		serviceNamespacedName := store.Labels[constants.ServiceLabelKey]
 		if serviceNamespacedName == "" {
 			klog.V(3).Infof("Store [%s.%s] Service mismatch", store.Namespace, store.Name)
 			continue
 		}
 
-		storageNamespacedName := store.Labels[monitoringv1alpha1.MonitoringPaodinStorage]
+		storageNamespacedName := store.Labels[constants.StorageLabelKey]
 		if storageNamespacedName == "" {
 			klog.V(3).Infof("Store [%s.%s] Storage mismatch", store.Namespace, store.Name)
 			continue
@@ -68,11 +69,11 @@ func (t *Tenant) store() error {
 
 	for _, v := range expectStores {
 		m := v.(map[string]string)
-		serviceNamespacedName := strings.Split(m[monitoringv1alpha1.MonitoringPaodinService], ".")
-		storageNamespacedName := strings.Split(m[monitoringv1alpha1.MonitoringPaodinStorage], ".")
+		serviceNamespacedName := strings.Split(m[constants.ServiceLabelKey], ".")
+		storageNamespacedName := strings.Split(m[constants.StorageLabelKey], ".")
 		store := &monitoringv1alpha1.Store{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: fmt.Sprintf("store-%s-%s-", serviceNamespacedName[1], storageNamespacedName[1]),
+				GenerateName: fmt.Sprintf("%s-%s-%s-", constants.AppNameStore, serviceNamespacedName[1], storageNamespacedName[1]),
 				Namespace:    serviceNamespacedName[0],
 				Labels:       m,
 			},
@@ -84,8 +85,8 @@ func (t *Tenant) store() error {
 
 		klog.V(3).Infof("Create store[%s.%s] for Service[%s] Storage[%s]",
 			store.Namespace, store.Name,
-			m[monitoringv1alpha1.MonitoringPaodinService],
-			m[monitoringv1alpha1.MonitoringPaodinStorage])
+			m[constants.ServiceLabelKey],
+			m[constants.StorageLabelKey])
 	}
 
 	return nil
@@ -105,12 +106,12 @@ func sortTenantsByStorageAndService(ctx context.Context, c client.Client) (map[s
 			continue
 		}
 
-		if tenant.Labels[monitoringv1alpha1.MonitoringPaodinStorage] == monitoringv1alpha1.MonitoringLocalStorage {
+		if tenant.Labels[constants.StorageLabelKey] == constants.LocalStorage {
 			klog.V(3).Infof("ignore tenant %s with local storage", tenant.Name)
 			continue
 		}
 
-		serviceNamespacedName := tenant.Labels[monitoringv1alpha1.MonitoringPaodinService]
+		serviceNamespacedName := tenant.Labels[constants.ServiceLabelKey]
 		if serviceNamespacedName == "" {
 			klog.V(3).Infof("ignore tenant %s without service", tenant.Name)
 			continue
@@ -140,8 +141,8 @@ func sortTenantsByStorageAndService(ctx context.Context, c client.Client) (map[s
 		}
 
 		storageMap[serviceNamespacedName+storageNamespacedName] = map[string]string{
-			monitoringv1alpha1.MonitoringPaodinService: serviceNamespacedName,
-			monitoringv1alpha1.MonitoringPaodinStorage: storageNamespacedName,
+			constants.ServiceLabelKey: serviceNamespacedName,
+			constants.StorageLabelKey: storageNamespacedName,
 		}
 	}
 

--- a/pkg/controllers/monitoring/resources/tenant/tenant.go
+++ b/pkg/controllers/monitoring/resources/tenant/tenant.go
@@ -1,9 +1,9 @@
 package tenant
 
 import (
-	monitoringv1alpha1 "github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/options"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
+	monitoringv1alpha1 "github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/options"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
 )
 
 type Tenant struct {

--- a/pkg/controllers/monitoring/ruler_controller.go
+++ b/pkg/controllers/monitoring/ruler_controller.go
@@ -34,10 +34,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	monitoringv1alpha1 "github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/options"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources/ruler"
+	monitoringv1alpha1 "github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/options"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources/ruler"
 )
 
 // RulerReconciler reconciles a Ruler object
@@ -50,12 +50,12 @@ type RulerReconciler struct {
 	Context context.Context
 }
 
-//+kubebuilder:rbac:groups=monitoring.paodin.io,resources=rulers,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=monitoring.paodin.io,resources=rulers/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=monitoring.paodin.io,resources=rulers/finalizers,verbs=update
-//+kubebuilder:rbac:groups=monitoring.paodin.io,resources=alertingrules,verbs=get;list;watch
-//+kubebuilder:rbac:groups=monitoring.paodin.io,resources=rulegroups,verbs=get;list;watch
-//+kubebuilder:rbac:groups=monitoring.paodin.io,resources=rules,verbs=get;list;watch
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=rulers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=rulers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=rulers/finalizers,verbs=update
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=alertingrules,verbs=get;list;watch
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=rulegroups,verbs=get;list;watch
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=rules,verbs=get;list;watch
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=services;configmaps,verbs=get;list;watch;create;update;patch;delete
@@ -219,7 +219,7 @@ func CreateRulerDefaulterValidator(opt options.Options) RulerDefaulterValidator 
 	return func(ruler *monitoringv1alpha1.Ruler) (*monitoringv1alpha1.Ruler, error) {
 
 		if ruler.Spec.Image == "" {
-			ruler.Spec.Image = opt.ThanosImage
+			ruler.Spec.Image = opt.WhizardImage
 		}
 		if ruler.Spec.Replicas == nil || *ruler.Spec.Replicas < 0 {
 			ruler.Spec.Replicas = &replicas

--- a/pkg/controllers/monitoring/service_controller.go
+++ b/pkg/controllers/monitoring/service_controller.go
@@ -19,6 +19,14 @@ package monitoring
 import (
 	"context"
 
+	monitoringv1alpha1 "github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/options"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources/gateway"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources/query"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources/query_frontend"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources/router"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -29,14 +37,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-
-	monitoringv1alpha1 "github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/options"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources/gateway"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources/query"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources/query_frontend"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources/router"
 )
 
 // ServiceReconciler reconciles a Service object
@@ -47,12 +47,12 @@ type ServiceReconciler struct {
 	Context context.Context
 }
 
-//+kubebuilder:rbac:groups=monitoring.paodin.io,resources=services,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=monitoring.paodin.io,resources=services/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=monitoring.paodin.io,resources=services/finalizers,verbs=update
-//+kubebuilder:rbac:groups=monitoring.paodin.io,resources=ingesters,verbs=get;list;watch
-//+kubebuilder:rbac:groups=monitoring.paodin.io,resources=stores,verbs=get;list;watch
-//+kubebuilder:rbac:groups=monitoring.paodin.io,resources=rulers,verbs=get;list;watch
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=services,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=services/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=services/finalizers,verbs=update
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=ingesters,verbs=get;list;watch
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=stores,verbs=get;list;watch
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=rulers,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=services;configmaps;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=deployments;statefulsets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
@@ -147,17 +147,17 @@ func CreateServiceDefaulterValidator(opt options.Options) ServiceDefaulterValida
 	return func(service *monitoringv1alpha1.Service) (*monitoringv1alpha1.Service, error) {
 
 		if service.Spec.TenantHeader == "" {
-			service.Spec.TenantHeader = monitoringv1alpha1.DefaultTenantHeader
+			service.Spec.TenantHeader = constants.DefaultTenantHeader
 		}
 		if service.Spec.TenantLabelName == "" {
-			service.Spec.TenantLabelName = monitoringv1alpha1.DefaultTenantLabelName
+			service.Spec.TenantLabelName = constants.DefaultTenantLabelName
 		}
 		if service.Spec.DefaultTenantId == "" {
-			service.Spec.DefaultTenantId = monitoringv1alpha1.DefaultTenantId
+			service.Spec.DefaultTenantId = constants.DefaultTenantId
 		}
 
 		if service.Spec.Gateway != nil && service.Spec.Gateway.Image == "" {
-			service.Spec.Gateway.Image = opt.PaodinMonitoringGatewayImage
+			service.Spec.Gateway.Image = opt.GatewayImage
 		}
 
 		if service.Spec.Query != nil {
@@ -165,7 +165,7 @@ func CreateServiceDefaulterValidator(opt options.Options) ServiceDefaulterValida
 				service.Spec.Query.Replicas = &replicas
 			}
 			if service.Spec.Query.Image == "" {
-				service.Spec.Query.Image = opt.ThanosImage
+				service.Spec.Query.Image = opt.WhizardImage
 			}
 			if service.Spec.Query.Envoy.Image == "" {
 				service.Spec.Query.Envoy.Image = opt.EnvoyImage
@@ -177,7 +177,7 @@ func CreateServiceDefaulterValidator(opt options.Options) ServiceDefaulterValida
 				service.Spec.Router.Replicas = &replicas
 			}
 			if service.Spec.Router.Image == "" {
-				service.Spec.Router.Image = opt.ThanosImage
+				service.Spec.Router.Image = opt.WhizardImage
 			}
 		}
 		if service.Spec.QueryFrontend != nil {
@@ -185,7 +185,7 @@ func CreateServiceDefaulterValidator(opt options.Options) ServiceDefaulterValida
 				service.Spec.QueryFrontend.Replicas = &replicas
 			}
 			if service.Spec.QueryFrontend.Image == "" {
-				service.Spec.QueryFrontend.Image = opt.ThanosImage
+				service.Spec.QueryFrontend.Image = opt.WhizardImage
 			}
 		}
 

--- a/pkg/controllers/monitoring/storage_controller.go
+++ b/pkg/controllers/monitoring/storage_controller.go
@@ -27,9 +27,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	monitoringv1alpha1 "github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources/storage"
+	monitoringv1alpha1 "github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources/storage"
 )
 
 // StorageReconciler reconciles a Storage object
@@ -39,7 +39,7 @@ type StorageReconciler struct {
 	Context context.Context
 }
 
-//+kubebuilder:rbac:groups=monitoring.paodin.io,resources=storages,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=storages,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to

--- a/pkg/controllers/monitoring/store_controller.go
+++ b/pkg/controllers/monitoring/store_controller.go
@@ -19,10 +19,11 @@ package monitoring
 import (
 	"context"
 
-	monitoringv1alpha1 "github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/options"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources"
-	"github.com/kubesphere/paodin/pkg/controllers/monitoring/resources/store"
+	monitoringv1alpha1 "github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/options"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources/store"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
@@ -48,9 +49,9 @@ type StoreReconciler struct {
 	Options options.StoreOptions
 }
 
-//+kubebuilder:rbac:groups=monitoring.paodin.io,resources=stores,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=monitoring.paodin.io,resources=stores/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=monitoring.paodin.io,resources=stores/finalizers,verbs=update
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=stores,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=stores/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=stores/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
@@ -112,7 +113,7 @@ func (r *StoreReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *StoreReconciler) mapToStoreByStorage(obj client.Object) []reconcile.Request {
 	storeList := &monitoringv1alpha1.StoreList{}
 
-	if err := r.List(r.Context, storeList, client.MatchingLabels{monitoringv1alpha1.MonitoringPaodinStorage: obj.GetNamespace() + "." + obj.GetName()}); err != nil {
+	if err := r.List(r.Context, storeList, client.MatchingLabels{constants.StorageLabelKey: obj.GetNamespace() + "." + obj.GetName()}); err != nil {
 		klog.Errorf("Enqueue store request from storage [%s.%s] failed, %s", obj.GetNamespace(), obj.GetName(), err)
 		return nil
 	}

--- a/pkg/controllers/monitoring/suite_test.go
+++ b/pkg/controllers/monitoring/suite_test.go
@@ -30,7 +30,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	monitoringv1alpha1 "github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
+	monitoringv1alpha1 "github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/pkg/util/k8s.go
+++ b/pkg/util/k8s.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/kubesphere/paodin/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"

--- a/tools/docgen/docgen.go
+++ b/tools/docgen/docgen.go
@@ -17,7 +17,7 @@ const (
 
 # API Docs
 
-This Document documents the types introduced by the paodin to be consumed by users.
+This Document documents the types introduced by the whizard to be consumed by users.
 
 > Note this document is generated from code comments. When contributing a change to this document please do so by changing the code comments.`
 )


### PR DESCRIPTION
Signed-off-by: wanjunlei <wanjunlei@kubesphere.io>

- Change all `thanos` to `whizard`, including the config file and tsdb path.
- Renamed the remaining thanos-related configuration, variables, and constants
- Regenerated API documentation