### PR TITLE
Adjust the logic of reconcile

### DIFF
--- a/cmd/controller-manager/app/controllers.go
+++ b/cmd/controller-manager/app/controllers.go
@@ -14,13 +14,43 @@ import (
 func addControllers(mgr manager.Manager, client k8s.Client, informerFactory informers.InformerFactory,
 	cmOptions *options.ControllerManagerOptions, ctx context.Context) error {
 
-	if err := (&monitoring.ServiceReconciler{
-		DefaulterValidator: monitoring.CreateServiceDefaulterValidator(*cmOptions.MonitoringOptions),
-		Client:             mgr.GetClient(),
-		Scheme:             mgr.GetScheme(),
-		Context:            ctx,
+	if err := (&monitoring.GatewayReconciler{
+		Client:  mgr.GetClient(),
+		Scheme:  mgr.GetScheme(),
+		Context: ctx,
+		Options: cmOptions.MonitoringOptions,
 	}).SetupWithManager(mgr); err != nil {
-		klog.Errorf("Unable to create Service controller: %v", err)
+		klog.Errorf("Unable to create Gateway controller: %v", err)
+		return err
+	}
+
+	if err := (&monitoring.QueryFrontendReconciler{
+		Client:  mgr.GetClient(),
+		Scheme:  mgr.GetScheme(),
+		Context: ctx,
+		Options: cmOptions.MonitoringOptions,
+	}).SetupWithManager(mgr); err != nil {
+		klog.Errorf("Unable to create Query Frontend controller: %v", err)
+		return err
+	}
+
+	if err := (&monitoring.QueryReconciler{
+		Client:  mgr.GetClient(),
+		Scheme:  mgr.GetScheme(),
+		Context: ctx,
+		Options: cmOptions.MonitoringOptions,
+	}).SetupWithManager(mgr); err != nil {
+		klog.Errorf("Unable to create Query controller: %v", err)
+		return err
+	}
+
+	if err := (&monitoring.RouterReconciler{
+		Client:  mgr.GetClient(),
+		Scheme:  mgr.GetScheme(),
+		Context: ctx,
+		Options: cmOptions.MonitoringOptions,
+	}).SetupWithManager(mgr); err != nil {
+		klog.Errorf("Unable to create Router controller: %v", err)
 		return err
 	}
 

--- a/pkg/constants/constans.go
+++ b/pkg/constants/constans.go
@@ -55,6 +55,9 @@ const (
 
 	TenantHash  = "TENANT_HASH"
 	StorageHash = "STORAGE_HASH"
+
+	IngesterStateDeleting = "deleting"
+	IngesterStateRunning  = "running"
 )
 
 const (

--- a/pkg/controllers/monitoring/gateway_controller.go
+++ b/pkg/controllers/monitoring/gateway_controller.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2021 The KubeSphere authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"context"
+
+	monitoringv1alpha1 "github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/options"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources/gateway"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// GatewayReconciler reconciles a Service object
+type GatewayReconciler struct {
+	client.Client
+	Scheme  *runtime.Scheme
+	Context context.Context
+	Options *options.Options
+}
+
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=services,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=services/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=services/finalizers,verbs=update
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the Service object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.0/pkg/reconcile
+func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	l := log.FromContext(ctx).WithValues("gateway", req.NamespacedName)
+
+	l.Info("sync")
+
+	instance := &monitoringv1alpha1.Service{}
+	err := r.Get(ctx, req.NamespacedName, instance)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	instance, err = r.validator(instance)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	gatewayReconciler := gateway.New(resources.ServiceBaseReconciler{
+		Service: instance,
+		BaseReconciler: resources.BaseReconciler{
+			Client:  r.Client,
+			Log:     l,
+			Scheme:  r.Scheme,
+			Context: ctx,
+		},
+	})
+
+	return ctrl.Result{}, gatewayReconciler.Reconcile()
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&monitoringv1alpha1.Service{}).
+		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.Service{}).
+		Owns(&corev1.ConfigMap{}).
+		Complete(r)
+}
+
+func (r *GatewayReconciler) validator(service *monitoringv1alpha1.Service) (*monitoringv1alpha1.Service, error) {
+	var replicas int32 = 1
+
+	if service.Spec.TenantHeader == "" {
+		service.Spec.TenantHeader = constants.DefaultTenantHeader
+	}
+	if service.Spec.TenantLabelName == "" {
+		service.Spec.TenantLabelName = constants.DefaultTenantLabelName
+	}
+	if service.Spec.DefaultTenantId == "" {
+		service.Spec.DefaultTenantId = constants.DefaultTenantId
+	}
+
+	if service.Spec.Gateway != nil {
+		if service.Spec.Gateway.Image == "" {
+			service.Spec.Gateway.Image = r.Options.GatewayImage
+		}
+
+		if service.Spec.Gateway.Replicas == nil || *service.Spec.Gateway.Replicas < 0 {
+			service.Spec.Gateway.Replicas = &replicas
+		}
+	}
+
+	return service, nil
+}

--- a/pkg/controllers/monitoring/query_frontend_controller.go
+++ b/pkg/controllers/monitoring/query_frontend_controller.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2021 The KubeSphere authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"context"
+
+	monitoringv1alpha1 "github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/options"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources/queryfrontend"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// QueryFrontendReconciler reconciles a Service object
+type QueryFrontendReconciler struct {
+	client.Client
+	Scheme  *runtime.Scheme
+	Context context.Context
+	Options *options.Options
+}
+
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=services,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=services/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=services/finalizers,verbs=update
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=tenants,verbs=get;list;watch
+//+kubebuilder:rbac:groups=core,resources=services;configmaps;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=apps,resources=deployments;statefulsets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the Service object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.0/pkg/reconcile
+func (r *QueryFrontendReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	l := log.FromContext(ctx).WithValues("query-frontend", req.NamespacedName)
+
+	l.Info("sync")
+
+	instance := &monitoringv1alpha1.Service{}
+	err := r.Get(ctx, req.NamespacedName, instance)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	instance, err = r.Validator(instance)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	queryFrontendReconciler := queryfrontend.New(
+		resources.ServiceBaseReconciler{
+			Service: instance,
+			BaseReconciler: resources.BaseReconciler{
+				Client:  r.Client,
+				Log:     l,
+				Scheme:  r.Scheme,
+				Context: ctx,
+			},
+		})
+
+	return ctrl.Result{}, queryFrontendReconciler.Reconcile()
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *QueryFrontendReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&monitoringv1alpha1.Service{}).
+		Watches(&source.Kind{Type: &monitoringv1alpha1.Tenant{}},
+			handler.EnqueueRequestsFromMapFunc(r.mapToServiceFunc)).
+		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.Service{}).
+		Owns(&corev1.ConfigMap{}).
+		Complete(r)
+}
+
+func (r *QueryFrontendReconciler) mapToServiceFunc(o client.Object) []reconcile.Request {
+	namespacedName := monitoringv1alpha1.ServiceNamespacedName(o)
+	if namespacedName == nil {
+		return nil
+	}
+
+	return []reconcile.Request{{
+		NamespacedName: *namespacedName,
+	}}
+}
+
+func (r *QueryFrontendReconciler) Validator(service *monitoringv1alpha1.Service) (*monitoringv1alpha1.Service, error) {
+
+	if service.Spec.TenantHeader == "" {
+		service.Spec.TenantHeader = constants.DefaultTenantHeader
+	}
+	if service.Spec.TenantLabelName == "" {
+		service.Spec.TenantLabelName = constants.DefaultTenantLabelName
+	}
+	if service.Spec.DefaultTenantId == "" {
+		service.Spec.DefaultTenantId = constants.DefaultTenantId
+	}
+
+	if service.Spec.QueryFrontend != nil {
+		if service.Spec.QueryFrontend.Replicas == nil || *service.Spec.QueryFrontend.Replicas < 0 {
+			var replicas int32 = 1
+			service.Spec.QueryFrontend.Replicas = &replicas
+		}
+		if service.Spec.QueryFrontend.Image == "" {
+			service.Spec.QueryFrontend.Image = r.Options.WhizardImage
+		}
+	}
+
+	return service, nil
+
+}

--- a/pkg/controllers/monitoring/resources/gateway/deployment.go
+++ b/pkg/controllers/monitoring/resources/gateway/deployment.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
 	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources/query"
-	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources/query_frontend"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources/queryfrontend"
 	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources/router"
 )
 
@@ -125,7 +125,7 @@ func (g *Gateway) deployment() (runtime.Object, resources.Operation, error) {
 	}
 
 	if g.Service.Spec.QueryFrontend != nil {
-		qf := query_frontend.New(g.ServiceBaseReconciler)
+		qf := queryfrontend.New(g.ServiceBaseReconciler)
 		container.Args = append(container.Args, fmt.Sprintf("--query.address=%s", qf.HttpAddr()))
 	} else if g.Service.Spec.Query != nil {
 		q := query.New(g.ServiceBaseReconciler)

--- a/pkg/controllers/monitoring/resources/queryfrontend/configmap.go
+++ b/pkg/controllers/monitoring/resources/queryfrontend/configmap.go
@@ -1,4 +1,4 @@
-package query_frontend
+package queryfrontend
 
 import (
 	"time"

--- a/pkg/controllers/monitoring/resources/queryfrontend/deployment.go
+++ b/pkg/controllers/monitoring/resources/queryfrontend/deployment.go
@@ -1,4 +1,4 @@
-package query_frontend
+package queryfrontend
 
 import (
 	"fmt"

--- a/pkg/controllers/monitoring/resources/queryfrontend/query_frontend.go
+++ b/pkg/controllers/monitoring/resources/queryfrontend/query_frontend.go
@@ -1,4 +1,4 @@
-package query_frontend
+package queryfrontend
 
 import (
 	"fmt"

--- a/pkg/controllers/monitoring/resources/queryfrontend/service.go
+++ b/pkg/controllers/monitoring/resources/queryfrontend/service.go
@@ -1,4 +1,4 @@
-package query_frontend
+package queryfrontend
 
 import (
 	"github.com/kubesphere/whizard/pkg/constants"

--- a/pkg/controllers/monitoring/resources/router/configmap.go
+++ b/pkg/controllers/monitoring/resources/router/configmap.go
@@ -2,15 +2,14 @@ package router
 
 import (
 	"encoding/json"
+	"github.com/kubesphere/whizard/pkg/constants"
 
+	monitoringv1alpha1 "github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources/ingester"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	monitoringv1alpha1 "github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
-	"github.com/kubesphere/whizard/pkg/constants"
-	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
-	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources/ingester"
 )
 
 func (r *Router) hashringsConfigMap() (runtime.Object, resources.Operation, error) {
@@ -44,7 +43,7 @@ func (r *Router) hashringsConfigMap() (runtime.Object, resources.Operation, erro
 		ingester := ingester.New(r.BaseReconciler, &item)
 		if len(item.Spec.Tenants) == 0 {
 			// the ingester in the "deleting" state will not be added to the soft hash ring
-			if v, ok := item.ObjectMeta.Labels[constants.LabelNameIngesterState]; !ok || v != "deleting" {
+			if v, ok := item.ObjectMeta.Labels[constants.LabelNameIngesterState]; !ok || v != constants.IngesterStateDeleting {
 				softHashring.Endpoints = append(softHashring.Endpoints, ingester.GrpcAddrs()...)
 			}
 			continue

--- a/pkg/controllers/monitoring/resources/tenant/ingestor.go
+++ b/pkg/controllers/monitoring/resources/tenant/ingestor.go
@@ -191,7 +191,7 @@ func (t *Tenant) removeTenantFromIngesterbyName(namespace, name string) error {
 				if annotation == nil {
 					annotation = make(map[string]string)
 				}
-				annotation[constants.LabelNameIngesterState] = "deleting"
+				annotation[constants.LabelNameIngesterState] = constants.IngesterStateDeleting
 				annotation[constants.LabelNameIngesterDeletingTime] = strconv.Itoa(int(time.Now().Add(t.Options.DefaultIngesterRetentionPeriod).Unix()))
 				ingester.Annotations = annotation
 			}
@@ -246,8 +246,8 @@ func addTenantToIngesterInstance(tenant *monitoringv1alpha1.Tenant, ingester *mo
 	ingester.Spec.Tenants = append(ingester.Spec.Tenants, tenant.Spec.Tenant)
 
 	annotation := ingester.GetAnnotations()
-	if v, ok := annotation[constants.LabelNameIngesterState]; ok && v == "deleting" {
-		annotation[constants.LabelNameIngesterState] = "running"
+	if v, ok := annotation[constants.LabelNameIngesterState]; ok && v == constants.IngesterStateDeleting {
+		annotation[constants.LabelNameIngesterState] = constants.IngesterStateRunning
 		annotation[constants.LabelNameIngesterDeletingTime] = ""
 	}
 	ingester.Annotations = annotation

--- a/pkg/controllers/monitoring/resources/tenant/store.go
+++ b/pkg/controllers/monitoring/resources/tenant/store.go
@@ -7,7 +7,6 @@ import (
 
 	monitoringv1alpha1 "github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
 	"github.com/kubesphere/whizard/pkg/constants"
-	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
@@ -58,44 +57,8 @@ func (t *Tenant) store() error {
 		return err
 	}
 
-	for k, v := range currentStores {
+	for k := range currentStores {
 		if _, ok := expectStores[k]; ok {
-			store := v.(*monitoringv1alpha1.Store)
-
-			if store.Annotations == nil {
-				store.Annotations = make(map[string]string)
-			}
-
-			tenantHash, err := resources.GetTenantHash(t.Context, t.Client, map[string]string{
-				constants.StorageLabelKey: store.Labels[constants.StorageLabelKey],
-				constants.ServiceLabelKey: store.Labels[constants.ServiceLabelKey],
-			})
-			if err != nil {
-				return err
-			}
-
-			storageHash, err := resources.GetStorageHash(t.Context, t.Client, store.Labels[constants.StorageLabelKey])
-			if err != nil {
-				return err
-			}
-
-			needUpdate := false
-			if store.Annotations[constants.LabelNameTenantHash] != tenantHash {
-				store.Annotations[constants.LabelNameTenantHash] = tenantHash
-				needUpdate = true
-			}
-
-			if store.Annotations[constants.LabelNameStorageHash] != tenantHash {
-				store.Annotations[constants.LabelNameStorageHash] = storageHash
-				needUpdate = true
-			}
-
-			if needUpdate {
-				if err := t.Client.Update(t.Context, store); err != nil {
-					return err
-				}
-			}
-
 			delete(currentStores, k)
 			delete(expectStores, k)
 		}
@@ -119,25 +82,8 @@ func (t *Tenant) store() error {
 				GenerateName: fmt.Sprintf("%s-%s-%s-", constants.AppNameStore, serviceNamespacedName[1], storageNamespacedName[1]),
 				Namespace:    serviceNamespacedName[0],
 				Labels:       m,
-				Annotations:  map[string]string{},
 			},
 		}
-
-		tenantHash, err := resources.GetTenantHash(t.Context, t.Client, map[string]string{
-			constants.StorageLabelKey: store.Labels[constants.StorageLabelKey],
-			constants.ServiceLabelKey: store.Labels[constants.ServiceLabelKey],
-		})
-		if err != nil {
-			return err
-		}
-
-		storageHash, err := resources.GetStorageHash(t.Context, t.Client, store.Labels[constants.StorageLabelKey])
-		if err != nil {
-			return err
-		}
-
-		store.Annotations[constants.LabelNameTenantHash] = tenantHash
-		store.Annotations[constants.LabelNameStorageHash] = storageHash
 
 		if err := t.Client.Create(t.Context, store); err != nil {
 			return err

--- a/pkg/controllers/monitoring/router_controller.go
+++ b/pkg/controllers/monitoring/router_controller.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2021 The KubeSphere authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"context"
+
+	monitoringv1alpha1 "github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
+	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/options"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources/router"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// RouterReconciler reconciles a Service object
+type RouterReconciler struct {
+	client.Client
+	Scheme  *runtime.Scheme
+	Context context.Context
+	Options *options.Options
+}
+
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=services,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=services/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=services/finalizers,verbs=update
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=ingesters,verbs=get;list;watch
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=stores,verbs=get;list;watch
+//+kubebuilder:rbac:groups=monitoring.whizard.io,resources=rulers,verbs=get;list;watch
+//+kubebuilder:rbac:groups=core,resources=services;configmaps;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=apps,resources=deployments;statefulsets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the Service object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.0/pkg/reconcile
+func (r *RouterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	l := log.FromContext(ctx).WithValues("service", req.NamespacedName)
+
+	l.Info("sync")
+
+	instance := &monitoringv1alpha1.Service{}
+	err := r.Get(ctx, req.NamespacedName, instance)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	instance, err = r.validator(instance)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	routerReconciler := router.New(
+		resources.ServiceBaseReconciler{
+			Service: instance,
+			BaseReconciler: resources.BaseReconciler{
+				Client:  r.Client,
+				Log:     l,
+				Scheme:  r.Scheme,
+				Context: ctx,
+			},
+		})
+
+	return ctrl.Result{}, routerReconciler.Reconcile()
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *RouterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&monitoringv1alpha1.Service{}).
+		Watches(&source.Kind{Type: &monitoringv1alpha1.Ingester{}},
+			handler.EnqueueRequestsFromMapFunc(r.mapToServiceFunc)).
+		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.Service{}).
+		Owns(&corev1.ConfigMap{}).
+		Complete(r)
+}
+
+func (r *RouterReconciler) mapToServiceFunc(o client.Object) []reconcile.Request {
+
+	namespacedName := monitoringv1alpha1.ServiceNamespacedName(o)
+
+	if namespacedName == nil {
+		return nil
+	}
+
+	return []reconcile.Request{{
+		NamespacedName: *namespacedName,
+	}}
+}
+
+func (r *RouterReconciler) validator(service *monitoringv1alpha1.Service) (*monitoringv1alpha1.Service, error) {
+	if service.Spec.TenantHeader == "" {
+		service.Spec.TenantHeader = constants.DefaultTenantHeader
+	}
+	if service.Spec.TenantLabelName == "" {
+		service.Spec.TenantLabelName = constants.DefaultTenantLabelName
+	}
+	if service.Spec.DefaultTenantId == "" {
+		service.Spec.DefaultTenantId = constants.DefaultTenantId
+	}
+
+	if service.Spec.Router != nil {
+		if service.Spec.Router.Replicas == nil || *service.Spec.Router.Replicas < 0 {
+			var replicas int32 = 1
+			service.Spec.Router.Replicas = &replicas
+		}
+		if service.Spec.Router.Image == "" {
+			service.Spec.Router.Image = r.Options.WhizardImage
+		}
+	}
+
+	return service, nil
+
+}


### PR DESCRIPTION
Signed-off-by: wanjunlei <wanjunlei@kubesphere.io>

Currently, whizard's reconciled logic is as follows

<img width="500" alt="1662109815(1)" src="https://user-images.githubusercontent.com/53003665/188106042-0bece171-e0fb-47ba-81f0-a83f9951f519.png">

There are some unnecessary reconcile, for example, storage changes will trigger gateway reconcile, it's unreasonable.

This pr will adjust the logic of reconciliation from the following aspects.

- The tenant controller no longer watches the storage CRD, the compactor controller, ingester controller, and store controller will watch the storage CRD by themselves.
- Split service controller into 4 controllers, gateway, query frontend, query, router, and watch different resources as needed.

