### PR TITLE
support multi rule selectors for ruler

### DIFF
--- a/config/crd/bases/monitoring.whizard.io_rulers.yaml
+++ b/config/crd/bases/monitoring.whizard.io_rulers.yaml
@@ -886,6 +886,13 @@ spec:
                 required:
                 - key
                 type: object
+              alertmanagersUrl:
+                description: 'Define URLs to send alerts to Alertmanager. Note: this
+                  field will be ignored if AlertmanagersConfig is specified. Maps
+                  to the `alertmanagers.url` arg.'
+                items:
+                  type: string
+                type: array
               dataVolume:
                 description: DataVolume specifies how volume shall be used
                 properties:
@@ -1338,51 +1345,58 @@ spec:
                       are ANDed.
                     type: object
                 type: object
-              ruleSelector:
-                description: A label selector to select which PrometheusRules to mount
-                  for alerting and recording.
-                properties:
-                  matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
-                    items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
-                      properties:
-                        key:
-                          description: key is the label key that the selector applies
-                            to.
-                          type: string
-                        operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
-                          type: string
-                        values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
-                          items:
+              ruleSelectors:
+                description: Label selectors to select which PrometheusRules to mount
+                  for alerting and recording. The result of multiple selectors are
+                  ORed.
+                items:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
-                          type: array
-                      required:
-                      - key
-                      - operator
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
-                    type: array
-                  matchLabels:
-                    additionalProperties:
-                      type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
-                    type: object
-                type: object
+                  type: object
+                type: array
               rulerQueryProxy:
                 properties:
                   image:

--- a/pkg/api/monitoring/v1alpha1/types.go
+++ b/pkg/api/monitoring/v1alpha1/types.go
@@ -488,9 +488,9 @@ type RulerSpec struct {
 
 	PrometheusConfigReloader SidecarSpec `json:"prometheusConfigReloader,omitempty"`
 
-	// A label selector to select which PrometheusRules to mount for alerting and
-	// recording.
-	RuleSelector *metav1.LabelSelector `json:"ruleSelector,omitempty"`
+	// Label selectors to select which PrometheusRules to mount for alerting and recording.
+	// The result of multiple selectors are ORed.
+	RuleSelectors []*metav1.LabelSelector `json:"ruleSelectors,omitempty"`
 	// Namespaces to be selected for PrometheusRules discovery. If unspecified, only
 	// the same namespace as the Ruler object is in is used.
 	RuleNamespaceSelector *metav1.LabelSelector `json:"ruleNamespaceSelector,omitempty"`
@@ -509,8 +509,12 @@ type RulerSpec struct {
 	// AlertDropLabels configure the label names which should be dropped in Ruler alerts.
 	// The replica label `ruler_replica` will always be dropped in alerts.
 	AlertDropLabels []string `json:"alertDropLabels,omitempty"`
+	// Define URLs to send alerts to Alertmanager.
+	// Note: this field will be ignored if AlertmanagersConfig is specified.
+	// Maps to the `alertmanagers.url` arg.
+	AlertmanagersURL []string `json:"alertmanagersUrl,omitempty"`
 	// Define configuration for connecting to alertmanager. Maps to the `alertmanagers.config` arg.
-	AlertManagersConfig *corev1.SecretKeySelector `json:"alertmanagersConfig,omitempty"`
+	AlertmanagersConfig *corev1.SecretKeySelector `json:"alertmanagersConfig,omitempty"`
 	// Interval between consecutive evaluations.
 	EvaluationInterval Duration `json:"evaluationInterval,omitempty"`
 

--- a/pkg/api/monitoring/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/monitoring/v1alpha1/zz_generated.deepcopy.go
@@ -982,10 +982,16 @@ func (in *RulerSpec) DeepCopyInto(out *RulerSpec) {
 	in.CommonSpec.DeepCopyInto(&out.CommonSpec)
 	in.RulerQueryProxy.DeepCopyInto(&out.RulerQueryProxy)
 	in.PrometheusConfigReloader.DeepCopyInto(&out.PrometheusConfigReloader)
-	if in.RuleSelector != nil {
-		in, out := &in.RuleSelector, &out.RuleSelector
-		*out = new(v1.LabelSelector)
-		(*in).DeepCopyInto(*out)
+	if in.RuleSelectors != nil {
+		in, out := &in.RuleSelectors, &out.RuleSelectors
+		*out = make([]*v1.LabelSelector, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(v1.LabelSelector)
+				(*in).DeepCopyInto(*out)
+			}
+		}
 	}
 	if in.RuleNamespaceSelector != nil {
 		in, out := &in.RuleNamespaceSelector, &out.RuleNamespaceSelector
@@ -1009,8 +1015,13 @@ func (in *RulerSpec) DeepCopyInto(out *RulerSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.AlertManagersConfig != nil {
-		in, out := &in.AlertManagersConfig, &out.AlertManagersConfig
+	if in.AlertmanagersURL != nil {
+		in, out := &in.AlertmanagersURL, &out.AlertmanagersURL
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.AlertmanagersConfig != nil {
+		in, out := &in.AlertmanagersConfig, &out.AlertmanagersConfig
 		*out = new(corev1.SecretKeySelector)
 		(*in).DeepCopyInto(*out)
 	}

--- a/pkg/controllers/monitoring/resources/ruler/statefulset.go
+++ b/pkg/controllers/monitoring/resources/ruler/statefulset.go
@@ -194,14 +194,18 @@ func (r *Ruler) statefulSet(shardSn int) (runtime.Object, resources.Operation, e
 		})
 	}
 
-	if r.ruler.Spec.AlertManagersConfig != nil {
+	if r.ruler.Spec.AlertmanagersConfig != nil {
 		container.Args = append(container.Args, "--alertmanagers.config=$(ALERTMANAGERS_CONFIG)")
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name: "ALERTMANAGERS_CONFIG",
 			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: r.ruler.Spec.AlertManagersConfig,
+				SecretKeyRef: r.ruler.Spec.AlertmanagersConfig,
 			},
 		})
+	} else if len(r.ruler.Spec.AlertmanagersURL) > 0 {
+		for _, url := range r.ruler.Spec.AlertmanagersURL {
+			container.Args = append(container.Args, fmt.Sprintf("--alertmanagers.url=%s", url))
+		}
 	}
 
 	if r.ruler.Spec.LogLevel != "" {


### PR DESCRIPTION
support multiple rule selectors for one `Ruler` instance, to select record and alert rules. eg:
```yaml
ruleSelectors: 
- matchLabels:
    role: record-rules
- matchLabels:
    alerting.kubesphere.io/owner_cluster: <cluster_name>
  matchExpressions:
  - key: alerting.kubesphere.io/rule_level
     operator: In
     values:
     - cluster
     - namespace
 ```

and add `alertmanagersUrl` item to `Ruler`
