### PR TITLE
fix query endpoint args and router hashring configuration

### DIFF
--- a/cmd/controller-manager/app/controllers.go
+++ b/cmd/controller-manager/app/controllers.go
@@ -38,7 +38,7 @@ func addControllers(mgr manager.Manager, client k8s.Client, informerFactory info
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Context: ctx,
-		Options: cmOptions.MonitoringOptions.Query,
+		Options: cmOptions.MonitoringOptions,
 	}).SetupWithManager(mgr); err != nil {
 		klog.Errorf("Unable to create Query controller: %v", err)
 		return err
@@ -48,7 +48,7 @@ func addControllers(mgr manager.Manager, client k8s.Client, informerFactory info
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Context: ctx,
-		Options: cmOptions.MonitoringOptions.Router,
+		Options: cmOptions.MonitoringOptions,
 	}).SetupWithManager(mgr); err != nil {
 		klog.Errorf("Unable to create Router controller: %v", err)
 		return err

--- a/pkg/controllers/monitoring/options/component.go
+++ b/pkg/controllers/monitoring/options/component.go
@@ -496,6 +496,9 @@ func (o *RulerOptions) ApplyTo(options *RulerOptions) {
 	if o.AlertDropLabels != nil {
 		options.AlertDropLabels = o.AlertDropLabels
 	}
+	if o.AlertmanagersURL != nil {
+		options.AlertmanagersURL = o.AlertmanagersURL
+	}
 	if o.AlertmanagersConfig != nil {
 		options.AlertmanagersConfig = o.AlertmanagersConfig
 	}

--- a/pkg/controllers/monitoring/query_controller.go
+++ b/pkg/controllers/monitoring/query_controller.go
@@ -44,7 +44,7 @@ type QueryReconciler struct {
 	client.Client
 	Scheme  *runtime.Scheme
 	Context context.Context
-	Options *options.QueryOptions
+	Options *options.Options
 }
 
 //+kubebuilder:rbac:groups=monitoring.whizard.io,resources=services,verbs=get;list;watch;create;update;patch;delete
@@ -93,6 +93,7 @@ func (r *QueryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			Context: ctx,
 		},
 		instance,
+		r.Options,
 	)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -142,6 +143,6 @@ func (r *QueryReconciler) mapFuncBySelectorFunc(fn func(metav1.Object) map[strin
 }
 
 func (r *QueryReconciler) validator(q *monitoringv1alpha1.Query) *monitoringv1alpha1.Query {
-	r.Options.Override(&q.Spec)
+	r.Options.Query.Override(&q.Spec)
 	return q
 }

--- a/pkg/controllers/monitoring/resources/gateway/deployment.go
+++ b/pkg/controllers/monitoring/resources/gateway/deployment.go
@@ -175,7 +175,7 @@ func (g *Gateway) queryAddress() (string, error) {
 		}
 
 		q := queryList.Items[0]
-		r, err := query.New(g.BaseReconciler, &q)
+		r, err := query.New(g.BaseReconciler, &q, nil)
 		if err != nil {
 			return "", err
 		}
@@ -198,7 +198,7 @@ func (g *Gateway) remoteWriteAddress() (string, error) {
 		}
 
 		o := routerList.Items[0]
-		r, err := router.New(g.BaseReconciler, &o)
+		r, err := router.New(g.BaseReconciler, &o, nil)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/controllers/monitoring/resources/query/deployment.go
+++ b/pkg/controllers/monitoring/resources/query/deployment.go
@@ -144,7 +144,8 @@ func (q *Query) deployment() (runtime.Object, resources.Operation, error) {
 		return nil, resources.OperationCreateOrUpdate, err
 	}
 	for _, item := range ingesterList.Items {
-		ingesterInstance, err := ingester.New(q.BaseReconciler, &item, nil)
+		q.Options.Ingester.Override(&item.Spec)
+		ingesterInstance, err := ingester.New(q.BaseReconciler, &item, q.Options.Ingester)
 		if err != nil {
 			return nil, "", err
 		}

--- a/pkg/controllers/monitoring/resources/query/query.go
+++ b/pkg/controllers/monitoring/resources/query/query.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
 	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/options"
 	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -19,16 +20,18 @@ const (
 
 type Query struct {
 	resources.BaseReconciler
-	query *v1alpha1.Query
+	query   *v1alpha1.Query
+	Options *options.Options
 }
 
-func New(reconciler resources.BaseReconciler, q *v1alpha1.Query) (*Query, error) {
+func New(reconciler resources.BaseReconciler, q *v1alpha1.Query, o *options.Options) (*Query, error) {
 	if err := reconciler.SetService(q); err != nil {
 		return nil, err
 	}
 	return &Query{
 		BaseReconciler: reconciler,
 		query:          q,
+		Options:        o,
 	}, nil
 }
 

--- a/pkg/controllers/monitoring/resources/queryfrontend/deployment.go
+++ b/pkg/controllers/monitoring/resources/queryfrontend/deployment.go
@@ -158,7 +158,7 @@ func (q *QueryFrontend) queryAddress() (string, error) {
 		}
 
 		o := queryList.Items[0]
-		r, err := query.New(q.BaseReconciler, &o)
+		r, err := query.New(q.BaseReconciler, &o, nil)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/controllers/monitoring/resources/router/configmap.go
+++ b/pkg/controllers/monitoring/resources/router/configmap.go
@@ -42,7 +42,8 @@ func (r *Router) hashringsConfigMap() (runtime.Object, resources.Operation, erro
 	}
 
 	for _, item := range ingesterList.Items {
-		ingester, err := ingester.New(r.BaseReconciler, &item, nil)
+		r.Options.Ingester.Override(&item.Spec)
+		ingester, err := ingester.New(r.BaseReconciler, &item, r.Options.Ingester)
 		if err != nil {
 			return nil, "", err
 		}

--- a/pkg/controllers/monitoring/resources/router/router.go
+++ b/pkg/controllers/monitoring/resources/router/router.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
 	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/options"
 	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -16,16 +17,18 @@ const (
 
 type Router struct {
 	resources.BaseReconciler
-	router *v1alpha1.Router
+	router  *v1alpha1.Router
+	Options *options.Options
 }
 
-func New(reconciler resources.BaseReconciler, r *v1alpha1.Router) (*Router, error) {
+func New(reconciler resources.BaseReconciler, r *v1alpha1.Router, o *options.Options) (*Router, error) {
 	if err := reconciler.SetService(r); err != nil {
 		return nil, err
 	}
 	return &Router{
 		BaseReconciler: reconciler,
 		router:         r,
+		Options:        o,
 	}, nil
 }
 

--- a/pkg/controllers/monitoring/resources/ruler/statefulset.go
+++ b/pkg/controllers/monitoring/resources/ruler/statefulset.go
@@ -359,7 +359,7 @@ func (r *Ruler) remoteWriteAddress() (string, error) {
 		}
 
 		o := routerList.Items[0]
-		r, err := router.New(r.BaseReconciler, &o)
+		r, err := router.New(r.BaseReconciler, &o, nil)
 		if err != nil {
 			return "", err
 		}
@@ -382,7 +382,7 @@ func (r *Ruler) queryAddress() (string, error) {
 		}
 
 		o := queryList.Items[0]
-		r, err := query.New(r.BaseReconciler, &o)
+		r, err := query.New(r.BaseReconciler, &o, nil)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/controllers/monitoring/router_controller.go
+++ b/pkg/controllers/monitoring/router_controller.go
@@ -44,7 +44,7 @@ type RouterReconciler struct {
 	client.Client
 	Scheme  *runtime.Scheme
 	Context context.Context
-	Options *options.RouterOptions
+	Options *options.Options
 }
 
 //+kubebuilder:rbac:groups=monitoring.whizard.io,resources=services,verbs=get;list;watch;create;update;patch;delete
@@ -93,6 +93,7 @@ func (r *RouterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			Context: ctx,
 		},
 		instance,
+		r.Options,
 	)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -138,7 +139,7 @@ func (r *RouterReconciler) mapFuncBySelectorFunc(fn func(metav1.Object) map[stri
 }
 
 func (r *RouterReconciler) validator(router *monitoringv1alpha1.Router) *monitoringv1alpha1.Router {
-	r.Options.Override(&router.Spec)
+	r.Options.Router.Override(&router.Spec)
 	return router
 
 }


### PR DESCRIPTION
the ingester uses the default replicas if no replicas configuration item, so configure endpoint args for query component and hashring configuration for router component with the same way.

and fix `AlertmanagersUrl` not override by default in ruler.