### PR TITLE
Change pvc to persistentVolumeClaim in CRD

### DIFF
--- a/config/bundle.yaml
+++ b/config/bundle.yaml
@@ -512,7 +512,7 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                     type: object
-                  pvc:
+                  persistentVolumeClaim:
                     description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
                     properties:
                       apiVersion:
@@ -1884,7 +1884,7 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                     type: object
-                  pvc:
+                  persistentVolumeClaim:
                     description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
                     properties:
                       apiVersion:
@@ -4524,7 +4524,7 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                     type: object
-                  pvc:
+                  persistentVolumeClaim:
                     description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
                     properties:
                       apiVersion:
@@ -6307,7 +6307,7 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                     type: object
-                  pvc:
+                  persistentVolumeClaim:
                     description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
                     properties:
                       apiVersion:

--- a/config/crd/bases/monitoring.whizard.io_compactors.yaml
+++ b/config/crd/bases/monitoring.whizard.io_compactors.yaml
@@ -887,7 +887,7 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                     type: object
-                  pvc:
+                  persistentVolumeClaim:
                     description: PersistentVolumeClaim is a user's request for and
                       claim to a persistent volume
                     properties:

--- a/config/crd/bases/monitoring.whizard.io_ingesters.yaml
+++ b/config/crd/bases/monitoring.whizard.io_ingesters.yaml
@@ -888,7 +888,7 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                     type: object
-                  pvc:
+                  persistentVolumeClaim:
                     description: PersistentVolumeClaim is a user's request for and
                       claim to a persistent volume
                     properties:

--- a/config/crd/bases/monitoring.whizard.io_rulers.yaml
+++ b/config/crd/bases/monitoring.whizard.io_rulers.yaml
@@ -920,7 +920,7 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                     type: object
-                  pvc:
+                  persistentVolumeClaim:
                     description: PersistentVolumeClaim is a user's request for and
                       claim to a persistent volume
                     properties:

--- a/config/crd/bases/monitoring.whizard.io_stores.yaml
+++ b/config/crd/bases/monitoring.whizard.io_stores.yaml
@@ -887,7 +887,7 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                     type: object
-                  pvc:
+                  persistentVolumeClaim:
                     description: PersistentVolumeClaim is a user's request for and
                       claim to a persistent volume
                     properties:

--- a/pkg/api/monitoring/v1alpha1/types.go
+++ b/pkg/api/monitoring/v1alpha1/types.go
@@ -312,7 +312,7 @@ type InMemoryResponseCacheConfig struct {
 // KubernetesVolume defines the configured volume for a instance.
 type KubernetesVolume struct {
 	EmptyDir              *corev1.EmptyDirVolumeSource  `json:"emptyDir,omitempty"`
-	PersistentVolumeClaim *corev1.PersistentVolumeClaim `json:"pvc,omitempty"`
+	PersistentVolumeClaim *corev1.PersistentVolumeClaim `json:"persistentVolumeClaim,omitempty"`
 }
 
 // IndexCacheConfig specifies the index cache config.


### PR DESCRIPTION
Change pvc to persistentVolumeClaim in CRD, because viper.Unmarshal does not work. Of course, it can also be solved with `mapstructure:"pvc,omitempty"`,but it shouldn't be in the CRD.

By the way, persistentVolumeClaim is more in line with the Kubernetes naming style.

Signed-off-by: frezes <zhangjunhao@kubesphere.io>