### PR TITLE
Revert "Bump golang from 1.19.3 to 1.19.5 in /build/monitoring-block-manager"

### DIFF
--- a/build/monitoring-block-manager/Dockerfile
+++ b/build/monitoring-block-manager/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19.5 as builder
+FROM golang:1.19.3 as builder
 ARG GOPROXY
 
 WORKDIR /workspace


### PR DESCRIPTION
Reverts WhizardTelemetry/whizard#144