### PR TITLE
add tenant selector in store

### DIFF
--- a/pkg/util/relabel_config.go
+++ b/pkg/util/relabel_config.go
@@ -1,0 +1,27 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+type relabelConfig struct {
+	Action        string   `yaml:"action"`
+	SourceLablels []string `yaml:"source_labels"`
+	Regex         string   `yaml:"regex"`
+}
+
+func CreateKeepTenantsRelabelConfig(tenantLabelName string, tenants []string) (string, error) {
+
+	regex := ""
+	for _, tenant := range tenants {
+		regex = fmt.Sprintf("%s|^%s$", regex, tenant)
+	}
+
+	return YamlMarshal([]relabelConfig{
+		{Action: "keep",
+			SourceLablels: []string{tenantLabelName},
+			Regex:         strings.TrimPrefix(regex, "|"),
+		},
+	})
+}

--- a/pkg/util/relable_config_test.go
+++ b/pkg/util/relable_config_test.go
@@ -1,0 +1,45 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCreateKeepTenantsRelabelConfig(t *testing.T) {
+	testCases := []struct {
+		name    string
+		label   string
+		regex   []string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "null case",
+			label:   "",
+			regex:   []string{},
+			want:    "- action: keep\n  source_labels:\n    - \"\"\n  regex: \"\"\n",
+			wantErr: false,
+		},
+		{
+			name:    "good case",
+			label:   "tenant_id",
+			regex:   []string{"host", "member-1"},
+			want:    "- action: keep\n  source_labels:\n    - tenant_id\n  regex: ^host$|^member-1$\n",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			got, err := CreateKeepTenantsRelabelConfig(tt.label, tt.regex)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateKeepTenantsRelabelConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateKeepTenantsRelabelConfig() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: frezes <zhangjunhao@kubesphere.io>

### What this PR does / why we need it:
Add a tenant selector to the store component so that other services can share storage and isolate data. The store no longer reads all data from the storage.