### PR TITLE
optimize tenant data cleaning on ingester

### DIFF
--- a/charts/whizard/templates/ingester/ingester.yaml
+++ b/charts/whizard/templates/ingester/ingester.yaml
@@ -15,6 +15,9 @@ metadata:
     {{- else }}
     "monitoring.whizard.io/storage": "local"
     {{- end }}
+    {{- with .Values.ingester.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
     {{- include "whizard.labels" . | nindent 4 }}
 spec:
   {{- if .Values.ingester.image }}

--- a/charts/whizard/values.yaml
+++ b/charts/whizard/values.yaml
@@ -414,6 +414,10 @@ ruler:
 ingester: 
   enabled: true
 
+  # add `"monitoring.whizard.io/soft-tenant"="true"` label for the soft tenant creation ingester
+  labels:
+    "monitoring.whizard.io/soft-tenant": "true"
+
   ## If null or unset, the value is determined based on enabled Service instance
   serviceReference: null
     # namespace: 

--- a/pkg/constants/constans.go
+++ b/pkg/constants/constans.go
@@ -9,7 +9,8 @@ const (
 	StorageLabelKey = "monitoring.whizard.io/storage"
 	TenantLabelKey  = "monitoring.whizard.io/tenant"
 
-	ExclusiveLabelKey = "monitoring.whizard.io/exclusive"
+	ExclusiveLabelKey  = "monitoring.whizard.io/exclusive"
+	SoftTenantLabelKey = "monitoring.whizard.io/soft-tenant"
 
 	FinalizerIngester  = "finalizers.monitoring.whizard.io/ingester"
 	FinalizerCompactor = "finalizers.monitoring.whizard.io/compactor"

--- a/pkg/controllers/monitoring/resources/router/configmap.go
+++ b/pkg/controllers/monitoring/resources/router/configmap.go
@@ -48,8 +48,8 @@ func (r *Router) hashringsConfigMap() (runtime.Object, resources.Operation, erro
 			return nil, "", err
 		}
 		if len(item.Spec.Tenants) == 0 {
-			// the ingester in the "deleting" state will not be added to the soft hash ring
-			if v, ok := item.ObjectMeta.Labels[constants.LabelNameIngesterState]; !ok || v != constants.IngesterStateDeleting {
+			// specific ingesters can join the softHashring
+			if v, ok := item.Labels[constants.SoftTenantLabelKey]; ok && v == "true" {
 				softHashring.Endpoints = append(softHashring.Endpoints, ingester.GrpcAddrs()...)
 			}
 			continue


### PR DESCRIPTION
### What this PR does / why we need it:
* ingester 的租户数据清理条件更宽松，在租户切换ingester时不再删除数据；
* 增加 `monitoring.whizard.io/unknown-tenant"="true"` 的标签，为软租户创建的 ingester 不再执行数据清理