### PR TITLE
allows global configuration to update compactor.retention

### DIFF
--- a/cmd/controller-manager/app/controllers.go
+++ b/cmd/controller-manager/app/controllers.go
@@ -70,6 +70,7 @@ func addControllers(mgr manager.Manager, client k8s.Client, informerFactory info
 		Client:             mgr.GetClient(),
 		Scheme:             mgr.GetScheme(),
 		Context:            ctx,
+		Options:            cmOptions.MonitoringOptions.Compactor,
 	}).SetupWithManager(mgr); err != nil {
 		klog.Errorf("Unable to create Compactor controller: %v", err)
 		return err

--- a/pkg/controllers/monitoring/compactor_controller.go
+++ b/pkg/controllers/monitoring/compactor_controller.go
@@ -43,6 +43,7 @@ import (
 // CompactorReconciler reconciles a compactor object
 type CompactorReconciler struct {
 	DefaulterValidator CompactorDefaulterValidator
+	Options            *options.CompactorOptions
 	client.Client
 	Scheme  *runtime.Scheme
 	Context context.Context
@@ -110,7 +111,7 @@ func (r *CompactorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		Context: ctx,
 	}
 
-	compactorReconciler, err := compactor.New(baseReconciler, instance)
+	compactorReconciler, err := compactor.New(baseReconciler, instance, r.Options)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/monitoring/resources/compactor/compactor.go
+++ b/pkg/controllers/monitoring/resources/compactor/compactor.go
@@ -3,6 +3,7 @@ package compactor
 import (
 	"github.com/kubesphere/whizard/pkg/api/monitoring/v1alpha1"
 	"github.com/kubesphere/whizard/pkg/constants"
+	"github.com/kubesphere/whizard/pkg/controllers/monitoring/options"
 	"github.com/kubesphere/whizard/pkg/controllers/monitoring/resources"
 	"github.com/kubesphere/whizard/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,15 +13,17 @@ import (
 type Compactor struct {
 	resources.BaseReconciler
 	compactor *v1alpha1.Compactor
+	option    *options.CompactorOptions
 }
 
-func New(reconciler resources.BaseReconciler, compactor *v1alpha1.Compactor) (*Compactor, error) {
+func New(reconciler resources.BaseReconciler, compactor *v1alpha1.Compactor, o *options.CompactorOptions) (*Compactor, error) {
 	if err := reconciler.SetService(compactor); err != nil {
 		return nil, err
 	}
 	return &Compactor{
 		BaseReconciler: reconciler,
 		compactor:      compactor,
+		option:         o,
 	}, nil
 }
 

--- a/pkg/controllers/monitoring/resources/compactor/statefulset.go
+++ b/pkg/controllers/monitoring/resources/compactor/statefulset.go
@@ -206,7 +206,15 @@ func (r *Compactor) megerArgs() ([]string, error) {
 	if r.compactor.Spec.DisableDownsampling != nil && *r.compactor.Spec.DisableDownsampling {
 		defaultArgs = append(defaultArgs, "--downsampling.disable")
 	}
-	if retention := r.Service.Spec.Retention; retention != nil {
+
+	var retention *v1alpha1.Retention
+	if r.Service.Spec.Retention != nil {
+		retention = r.Service.Spec.Retention
+	} else if r.option.Retention != nil {
+		retention = r.option.Retention
+	}
+
+	if retention != nil {
 		if retention.RetentionRaw != "" {
 			defaultArgs = append(defaultArgs, fmt.Sprintf("--retention.resolution-raw=%s", retention.RetentionRaw))
 		}


### PR DESCRIPTION
Perhaps it would be better to move "retention" to `compactor crd` in the next release. 