### PR TITLE
fix wrong flag for store

### DIFF
--- a/charts/whizard/values.yaml
+++ b/charts/whizard/values.yaml
@@ -182,7 +182,7 @@ controllerManager:
       additionalFlags: 
       - --max-time=-24h     #The last 24h data is queried on ingester instead of store.
       - --web.disable      #Disable Block Viewer UI.
-      - --disable-caching-index-header-file #Support disabling cache index header file. When toggled, Stores can run without needing persistent disks.
+      - --no-cache-index-header #Support disabling cache index header file. When toggled, Stores can run without needing persistent disks.
 
     compactor: 
       ## If null or unset, the global.whizardImage is used.


### PR DESCRIPTION
the flag to cache TSDB index-headers on disk is `--cache-index-header`, so `--no-cache-index-header` for disabling.

and the descrition for `disable-caching-index-header-file`  in [thanos release log](https://github.com/thanos-io/thanos/releases/tag/v0.31.0)  is incorrect