### PR TITLE
remove alpn_protocols in envoy config

### DIFF
--- a/pkg/util/envoy_config.go
+++ b/pkg/util/envoy_config.go
@@ -110,7 +110,6 @@ static_resources:
         common_tls_context:
           validation_context:
             trust_chain_verification: ACCEPT_UNTRUSTED
-          alpn_protocols: 'h2,http/1.1'
         sni: {{ .ProxyServiceAddress }}
 {{ end }} 
 `)))


### PR DESCRIPTION
增加TLS 配置后，请求会概率性出现如下日志报错:
“upstream connect error or disconnect/reset before headers. reset reason: connection termination”

移除`alpn_protocols` 字段后正常，验证中；