### PR TITLE
[gateway] replace tenant matcher for query api

### DIFF
--- a/pkg/monitoring-gateway/handler.go
+++ b/pkg/monitoring-gateway/handler.go
@@ -123,7 +123,8 @@ func (h *Handler) query(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	enforcer := injectproxy.NewEnforcer(true, &labels.Matcher{
+	// Set errorOnReplace to false to directly replace the existing tenant with the new TenantId without reporting an error.
+	enforcer := injectproxy.NewEnforcer(false, &labels.Matcher{
 		Type:  labels.MatchEqual,
 		Name:  h.options.TenantLabelName,
 		Value: requestInfo.TenantId,
@@ -180,11 +181,6 @@ func (h *Handler) matcher(matchersParam string) http.HandlerFunc {
 
 		if !found || requestInfo.TenantId == "" {
 			http.NotFound(w, req)
-			return
-		}
-
-		if requestInfo.TenantId == "" {
-			h.queryProxy.ServeHTTP(w, req)
 			return
 		}
 


### PR DESCRIPTION
For query API, If the `query` param contains  a tenant matcher, it should be overrided by specified tenant in the request path, not return error for inconformity