### PR TITLE
[controller/ingester] sort tenants to avoid unnessary update to cleanup container

### DIFF
--- a/pkg/controllers/monitoring/resources/ingester/statefulset.go
+++ b/pkg/controllers/monitoring/resources/ingester/statefulset.go
@@ -235,6 +235,7 @@ func (r *Ingester) generateInitContainer(tsdbVolumeMount *corev1.VolumeMount) []
 	for _, tenant := range r.ingester.Status.Tenants {
 		tenants = append(tenants, tenant.Name)
 	}
+	sort.Strings(tenants)
 
 	return []corev1.Container{
 		{


### PR DESCRIPTION
 An update with only the tenants order change happened to the ingester statefulset, which should be avoided by sorting the tenants.
![image](https://github.com/WhizardTelemetry/whizard/assets/49136171/092c8fdf-dfff-4441-9cb0-73813a0d2dca)