### PR TITLE
support to disable auto select alerting rules in tenant ruler

### DIFF
--- a/charts/whizard/Chart.yaml
+++ b/charts/whizard/Chart.yaml
@@ -14,5 +14,5 @@ maintainers:
     email: junhaozhang@kubesphere.io
   - name: junot
     email: junotxiang@kubesphere.io
-version: 0.9.5
+version: 0.9.6
 appVersion: "latest"

--- a/charts/whizard/templates/controller-manager/configmap.yaml
+++ b/charts/whizard/templates/controller-manager/configmap.yaml
@@ -321,6 +321,9 @@ data:
         ruleNamespaceSelector:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- if eq (kindOf $ruler.disableAlertingRulesAutoSelection) "bool" }}
+        disableAlertingRulesAutoSelection: {{ $ruler.disableAlertingRulesAutoSelection }}
+        {{- end }}
         {{- with $ruler.alertmanagersUrl }}
         alertmanagersUrl:
           {{- toYaml . | nindent 10 }}

--- a/pkg/controllers/monitoring/options/component.go
+++ b/pkg/controllers/monitoring/options/component.go
@@ -461,6 +461,8 @@ type RulerOptions struct {
 	// Namespaces to be selected for PrometheusRules discovery. If unspecified, only
 	// the same namespace as the Ruler object is in is used.
 	RuleNamespaceSelector *metav1.LabelSelector `json:"ruleNamespaceSelector,omitempty"`
+	// If true, the tenant ruler will not select alerting rules associated with this tenant(cluster)
+	DisableAlertingRulesAutoSelection *bool `json:"disableAlertingRulesAutoSelection,omitempty"`
 
 	// Labels configure the external label pairs to Ruler. A default replica label
 	// `ruler_replica` will be always added  as a label with the value of the pod's name and it will be dropped in the alerts.
@@ -572,6 +574,9 @@ func (o *RulerOptions) ApplyTo(options *RulerOptions) {
 	}
 	if o.RuleNamespaceSelector != nil {
 		options.RuleNamespaceSelector = o.RuleNamespaceSelector
+	}
+	if o.DisableAlertingRulesAutoSelection != nil {
+		options.DisableAlertingRulesAutoSelection = o.DisableAlertingRulesAutoSelection
 	}
 	if o.Labels != nil {
 		options.Labels = o.Labels


### PR DESCRIPTION
previously a tenant ruler for a cluster will auto select alerting rules of its cluster.
in 4.x, the recording rules and alerting rules will be evaluated by different rulers.
so add a support to disable the auto selection.