### PR TITLE
change disableAlertingRulesAutoSelection default to be true

### DIFF
--- a/charts/whizard/Chart.yaml
+++ b/charts/whizard/Chart.yaml
@@ -14,5 +14,5 @@ maintainers:
     email: junhaozhang@kubesphere.io
   - name: junot
     email: junotxiang@kubesphere.io
-version: 0.10.2
+version: 0.10.3
 appVersion: "latest"

--- a/charts/whizard/crds/monitoring.whizard.io_services.yaml
+++ b/charts/whizard/crds/monitoring.whizard.io_services.yaml
@@ -11881,9 +11881,9 @@ spec:
                         type: object
                     type: object
                   disableAlertingRulesAutoSelection:
-                    default: false
+                    default: true
                     description: "DisableAlertingRulesAutoSelection disable auto select
-                      alerting rules in tenant ruler \n Default: false"
+                      alerting rules in tenant ruler \n Default: true"
                     type: boolean
                   evaluationInterval:
                     default: 1m

--- a/config/crd/bases/monitoring.whizard.io_services.yaml
+++ b/config/crd/bases/monitoring.whizard.io_services.yaml
@@ -11881,9 +11881,9 @@ spec:
                         type: object
                     type: object
                   disableAlertingRulesAutoSelection:
-                    default: false
+                    default: true
                     description: "DisableAlertingRulesAutoSelection disable auto select
-                      alerting rules in tenant ruler \n Default: false"
+                      alerting rules in tenant ruler \n Default: true"
                     type: boolean
                   evaluationInterval:
                     default: 1m

--- a/pkg/api/monitoring/v1alpha1/service_types.go
+++ b/pkg/api/monitoring/v1alpha1/service_types.go
@@ -80,8 +80,8 @@ type RulerTemplateSpec struct {
 
 	// DisableAlertingRulesAutoSelection disable auto select alerting rules in tenant ruler
 	//
-	// Default: false
-	// +kubebuilder:default:=false
+	// Default: true
+	// +kubebuilder:default:=true
 	DisableAlertingRulesAutoSelection *bool `json:"disableAlertingRulesAutoSelection,omitempty"`
 }
 


### PR DESCRIPTION
because tenant ruler will only eval recording rules, and alerting ruler for all alerting rules 